### PR TITLE
feat: Implement Content Security Policy and security headers

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -20,6 +20,7 @@ import { setupAutoUpdater } from './autoUpdater';
 import { setupEventListeners } from './events';
 import { AppServices } from './ipc/types';
 import { ClaudeCodeManager } from './services/claudeCodeManager';
+import { setupContentSecurityPolicy, setupAdditionalSecurity } from './security/contentSecurityPolicy';
 
 let mainWindow: BrowserWindow | null = null;
 let taskQueue: TaskQueue | null = null;
@@ -388,7 +389,14 @@ async function initializeServices() {
 }
 
 app.whenReady().then(async () => {
-  console.log('[Main] App is ready, initializing services...');
+  console.log('[Main] App is ready, setting up security policies...');
+  
+  // Setup security measures before creating window
+  setupContentSecurityPolicy();
+  setupAdditionalSecurity();
+  console.log('[Main] Security policies configured');
+  
+  console.log('[Main] Initializing services...');
   await initializeServices();
   console.log('[Main] Services initialized, creating window...');
   await createWindow();

--- a/main/src/security/contentSecurityPolicy.ts
+++ b/main/src/security/contentSecurityPolicy.ts
@@ -1,0 +1,99 @@
+import { session } from 'electron';
+
+/**
+ * Configure Content Security Policy for the application
+ * This helps prevent XSS attacks by restricting what resources can be loaded
+ */
+export function setupContentSecurityPolicy(): void {
+  // Configure CSP for the default session
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    const responseHeaders = { ...details.responseHeaders };
+    
+    // Define strict CSP policy
+    const cspPolicy = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'", // Required for Monaco editor and React
+      "style-src 'self' 'unsafe-inline'", // Required for inline styles
+      "img-src 'self' data: https:", // Allow images from self, data URIs, and HTTPS
+      "font-src 'self' data:", // Allow fonts from self and data URIs
+      "connect-src 'self' ws://localhost:* http://localhost:* https://api.github.com https://*.anthropic.com", // API connections
+      "media-src 'self'",
+      "object-src 'none'", // Disable plugins
+      "frame-src 'none'", // Disable iframes
+      "base-uri 'self'", // Restrict base tag
+      "form-action 'self'", // Restrict form submissions
+      "frame-ancestors 'none'", // Prevent clickjacking
+      "upgrade-insecure-requests" // Upgrade HTTP to HTTPS
+    ].join('; ');
+    
+    // Set security headers
+    responseHeaders['Content-Security-Policy'] = [cspPolicy];
+    responseHeaders['X-Content-Type-Options'] = ['nosniff'];
+    responseHeaders['X-Frame-Options'] = ['DENY'];
+    responseHeaders['X-XSS-Protection'] = ['1; mode=block'];
+    responseHeaders['Referrer-Policy'] = ['strict-origin-when-cross-origin'];
+    responseHeaders['Permissions-Policy'] = ['camera=(), microphone=(), geolocation=()'];
+    
+    callback({ responseHeaders });
+  });
+}
+
+/**
+ * Configure additional security measures
+ */
+export function setupAdditionalSecurity(): void {
+  // Prevent navigation to external websites
+  session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
+    const url = new URL(details.url);
+    
+    // Allow navigation to localhost (development) and file:// protocol
+    if (url.protocol === 'file:' || 
+        url.hostname === 'localhost' || 
+        url.hostname === '127.0.0.1') {
+      callback({ cancel: false });
+      return;
+    }
+    
+    // Allow specific trusted domains
+    const trustedDomains = [
+      'api.github.com',
+      'github.com',
+      'anthropic.com',
+      'claude.ai'
+    ];
+    
+    const isTrusted = trustedDomains.some(domain => 
+      url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+    );
+    
+    if (!isTrusted) {
+      console.warn(`[Security] Blocked navigation to untrusted domain: ${url.hostname}`);
+      callback({ cancel: true });
+    } else {
+      callback({ cancel: false });
+    }
+  });
+  
+  // Disable or limit certain web APIs
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    // Deny dangerous permissions
+    const deniedPermissions = [
+      'media',
+      'geolocation',
+      'notifications',
+      'midi',
+      'camera',
+      'microphone',
+      'usb',
+      'serial',
+      'bluetooth'
+    ];
+    
+    if (deniedPermissions.includes(permission)) {
+      console.warn(`[Security] Denied permission request: ${permission}`);
+      callback(false);
+    } else {
+      callback(true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Implemented comprehensive Content Security Policy (CSP) to prevent XSS attacks
- Added security headers to protect against common web vulnerabilities
- Configured request filtering and permission handling

## Security Improvements
1. **Content Security Policy**: Restricts resource loading to prevent XSS
2. **Security Headers**: X-Frame-Options, X-XSS-Protection, Referrer-Policy, etc.
3. **Domain Filtering**: Blocks requests to untrusted domains
4. **Permission Control**: Denies dangerous permissions like camera, microphone, etc.

## Changes
- Created `contentSecurityPolicy.ts` module with security configurations
- Updated main process to apply security policies before window creation
- Configured strict CSP rules while allowing necessary resources (Monaco editor, React)
- Added domain whitelist for trusted services (GitHub, Anthropic)

## CSP Configuration
```
default-src 'self'
script-src 'self' 'unsafe-inline' 'unsafe-eval'  // Required for Monaco/React
style-src 'self' 'unsafe-inline'
img-src 'self' data: https:
connect-src 'self' ws://localhost:* http://localhost:* https://api.github.com https://*.anthropic.com
frame-src 'none'
object-src 'none'
```

## Test Plan
- [ ] Verify application loads without CSP violations
- [ ] Test Monaco editor functionality
- [ ] Confirm external resource blocking works
- [ ] Check that API calls to GitHub/Anthropic still function
- [ ] Verify dangerous permissions are blocked

## Additional Notes
The CSP allows 'unsafe-inline' and 'unsafe-eval' for scripts due to Monaco editor and React requirements. Future improvements could include nonce-based CSP for better security.

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)