### PR TITLE
Enable strict port checking for Vite dev server

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
     plugins: [react()],
     server: {
         port: 4521,
+        strictPort: true,
         proxy: {
             '/api': {
                 target: 'http://localhost:3001',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,8 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 4521
+    port: 4521,
+    strictPort: true
   },
   base: './',
   build: {


### PR DESCRIPTION
## Summary
- Enabled `strictPort: true` in Vite configuration to prevent port conflicts when running multiple Crystal instances

## Problem
When working with multiple worktrees, it's confusing when multiple Electron apps can run on one dev server and fight over the port. This creates a race condition where whichever instance started first wins, leading to:
- Changes from one worktree not being reflected in the dev server
- Confusion when seeing changes from other worktrees unexpectedly

## Solution
Added `strictPort: true` to both `frontend/vite.config.ts` and `frontend/vite.config.js`. This makes Vite fail immediately with a clear error message when the port is already in use, rather than silently connecting to the wrong instance.

## Testing
Tested locally by:
1. Starting the dev server in one worktree
2. Attempting to start it in another worktree
3. Confirmed it fails with: `Error: Port 4521 is already in use`

## Future Considerations
The user mentioned being curious about dynamically generating ports based on the worktree, but this seemed like a safe intermediate fix to prevent confusion when using multiple worktrees.

## Changes
- `frontend/vite.config.ts`: Added `strictPort: true` to server configuration
- `frontend/vite.config.js`: Added `strictPort: true` to server configuration