### PR TITLE
Fix notification settings toggle visual feedback

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSessionStore } from '../stores/sessionStore';
 
 interface NotificationSettings {
@@ -12,7 +12,7 @@ interface NotificationSettings {
 export function useNotifications() {
   const sessions = useSessionStore((state) => state.sessions);
   const prevSessionsRef = useRef<typeof sessions>([]);
-  const settings = useRef<NotificationSettings>({
+  const [settings, setSettings] = useState<NotificationSettings>({
     enabled: true,
     playSound: true,
     notifyOnStatusChange: true,
@@ -39,7 +39,7 @@ export function useNotifications() {
   };
 
   const playNotificationSound = () => {
-    if (!settings.current.playSound) return;
+    if (!settings.playSound) return;
     
     try {
       // Create a simple notification sound using Web Audio API
@@ -64,7 +64,7 @@ export function useNotifications() {
   };
 
   const showNotification = (title: string, body: string, icon?: string) => {
-    if (!settings.current.enabled) return;
+    if (!settings.enabled) return;
 
     requestPermission().then((hasPermission) => {
       if (hasPermission) {
@@ -112,7 +112,7 @@ export function useNotifications() {
       
       if (!prevSession) {
         // New session created
-        if (settings.current.notifyOnStatusChange) {
+        if (settings.notifyOnStatusChange) {
           showNotification(
             `New Session Created ${getStatusEmoji('initializing')}`,
             `"${currentSession.name}" is starting up`
@@ -127,12 +127,12 @@ export function useNotifications() {
         const message = getStatusMessage(currentSession.status);
         
         // Notify based on specific status
-        if (currentSession.status === 'waiting' && settings.current.notifyOnWaiting) {
+        if (currentSession.status === 'waiting' && settings.notifyOnWaiting) {
           showNotification(
             `Input Required ${emoji}`,
             `"${currentSession.name}" is waiting for your response`
           );
-        } else if (currentSession.status === 'stopped' && settings.current.notifyOnComplete) {
+        } else if (currentSession.status === 'stopped' && settings.notifyOnComplete) {
           showNotification(
             `Session Complete ${emoji}`,
             `"${currentSession.name}" has finished`
@@ -142,7 +142,7 @@ export function useNotifications() {
             `Session Error ${emoji}`,
             `"${currentSession.name}" encountered an error`
           );
-        } else if (settings.current.notifyOnStatusChange) {
+        } else if (settings.notifyOnStatusChange) {
           showNotification(
             `Status Update ${emoji}`,
             `"${currentSession.name}" ${message}`
@@ -161,9 +161,9 @@ export function useNotifications() {
   }, []);
 
   return {
-    settings: settings.current,
+    settings,
     updateSettings: (newSettings: Partial<NotificationSettings>) => {
-      settings.current = { ...settings.current, ...newSettings };
+      setSettings(prev => ({ ...prev, ...newSettings }));
     },
     requestPermission,
     showNotification,


### PR DESCRIPTION
## Description

This PR fixes the issue where notification settings toggles don't provide visual feedback when clicked. The toggles now immediately update their appearance (color and position) when clicked, providing proper user feedback.

## Problem

When clicking toggle switches in the notification settings panel, they appeared frozen and didn't update visually, making it seem like the UI was broken. The settings were actually being saved, but users had no way to know this without closing and reopening the settings panel.

## Solution

Changed the notification settings storage from `useRef` to `useState` in the `useNotifications` hook. This ensures React knows to re-render the component when settings are updated.

### Changes made:
- Updated `frontend/src/hooks/useNotifications.ts`:
  - Changed settings from `useRef` to `useState`
  - Updated all references from `settings.current` to `settings`
  - Modified `updateSettings` to use the state setter function

## Testing

- [x] Tested in development mode - toggles now update immediately
- [x] Ran `pnpm typecheck` - all tests pass
- [x] Ran `pnpm lint` - no new errors introduced
- [x] Manually tested all notification toggles work correctly
- [x] Settings persist after closing and reopening the panel

## Screenshots

### Before
Toggles appeared frozen when clicked, no visual feedback

### After
Toggles now slide and change color immediately when clicked

## Related Issue

Fixes #56

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of my own code
- [x] No new warnings introduced
- [x] Settings functionality still works correctly
- [x] UI is responsive and provides immediate feedback