### PR TITLE
feat: Add persistent version display with git commit SHA

### DIFF
--- a/frontend/src/components/AboutDialog.tsx
+++ b/frontend/src/components/AboutDialog.tsx
@@ -11,6 +11,7 @@ interface VersionInfo {
   publishedAt?: string;
   workingDirectory?: string;
   buildDate?: string;
+  gitCommit?: string;
 }
 
 interface AboutDialogProps {
@@ -45,7 +46,8 @@ export function AboutDialog({ isOpen, onClose }: AboutDialogProps) {
           latest: result.data.current,
           hasUpdate: false,
           workingDirectory: result.data.workingDirectory,
-          buildDate: result.data.buildDate
+          buildDate: result.data.buildDate,
+          gitCommit: result.data.gitCommit
         });
       }
     } catch (error) {
@@ -151,13 +153,24 @@ export function AboutDialog({ isOpen, onClose }: AboutDialogProps) {
               </span>
             </div>
 
-            {versionInfo?.workingDirectory && !isPackaged && (
+            {versionInfo?.workingDirectory && (
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Working Directory
                 </span>
                 <span className="text-sm text-gray-900 dark:text-white font-mono truncate max-w-[200px]" title={versionInfo.workingDirectory}>
                   {versionInfo.workingDirectory.split('/').pop() || versionInfo.workingDirectory}
+                </span>
+              </div>
+            )}
+
+            {versionInfo?.gitCommit && (
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Git Commit
+                </span>
+                <span className="text-sm text-gray-900 dark:text-white font-mono">
+                  {versionInfo.gitCommit}
                 </span>
               </div>
             )}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Settings } from './Settings';
 import { DraggableProjectTreeView } from './DraggableProjectTreeView';
 import { Info, Clock } from 'lucide-react';
@@ -15,6 +15,29 @@ interface SidebarProps {
 export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, width, onResize }: SidebarProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [showStatusGuide, setShowStatusGuide] = useState(false);
+  const [version, setVersion] = useState<string>('');
+  const [gitCommit, setGitCommit] = useState<string>('');
+
+  useEffect(() => {
+    // Fetch version info on component mount
+    const fetchVersion = async () => {
+      try {
+        const result = await window.electronAPI.getVersionInfo();
+        if (result.success && result.data) {
+          if (result.data.current) {
+            setVersion(result.data.current);
+          }
+          if (result.data.gitCommit) {
+            setGitCommit(result.data.gitCommit);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch version:', error);
+      }
+    };
+    
+    fetchVersion();
+  }, []);
 
   return (
     <>
@@ -57,15 +80,6 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, width
               </svg>
             </button>
             <button
-              onClick={onAboutClick}
-              className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
-              title="About Crystal"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </button>
-            <button
               onClick={() => setIsSettingsOpen(true)}
               data-testid="settings-button"
               className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
@@ -102,6 +116,19 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, width
           </div>
           <DraggableProjectTreeView />
         </div>
+        
+        {/* Version display at bottom */}
+        {version && (
+          <div className="px-4 py-2 border-t border-gray-200 dark:border-gray-700">
+            <div 
+              className="text-xs text-gray-500 dark:text-gray-500 text-center cursor-pointer hover:text-gray-700 dark:hover:text-gray-400 transition-colors"
+              onClick={onAboutClick}
+              title="Click to view version details"
+            >
+              v{version}{gitCommit && ` • ${gitCommit}`}
+            </div>
+          </div>
+        )}
     </div>
 
       <Settings isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />


### PR DESCRIPTION
## Summary

This PR adds a persistent version display at the bottom of the sidebar that shows the current version and git commit SHA during development. This significantly improves the developer experience when working on Crystal with multiple versions or worktrees.

Fixes #60

## Changes

### 1. **Persistent Version Display**
- Added version display at the bottom of the sidebar that's always visible
- Shows `v0.1.14` in production
- Shows `v0.1.14 • 3531ee3` in development (with git commit SHA)
- Shows `v0.1.14 • 3531ee3 (modified)` when there are uncommitted changes
- Clicking the version opens the About dialog for more details

### 2. **Streamlined UI**
- Removed the info icon (i) from the top bar to reduce clutter
- Version info is now more prominent and accessible
- Follows common app patterns where version is always visible

### 3. **Smart Git Integration**
- Automatically detects git commit SHA during development
- Gracefully handles cases where git info isn't available (packaged builds)
- No "Unknown" text shown - git commit section is simply hidden when not available

## Screenshots

<details>
<summary>Development Mode</summary>

Shows version with git commit SHA at the bottom of sidebar:
`v0.1.14 • 3531ee3`

</details>

<details>
<summary>Production Mode</summary>

Shows only version number:
`v0.1.14`

</details>

## Benefits

1. **Development**: Instantly identify which commit you're running when working with multiple worktrees
2. **Support**: Users can see their version at a glance, making bug reports easier
3. **Professional**: Persistent version display signals active maintenance
4. **Cleaner UI**: Removes redundant UI elements

## Technical Details

- Modified `Sidebar.tsx` to add version display with git commit
- Updated `AboutDialog.tsx` to conditionally show git commit info
- Updated `updater.ts` to return git commit when available
- No new dependencies or build scripts required
- TypeScript checks pass