### PR TITLE
Fix Messages tab for debugging Claude Code JSON output

### DIFF
--- a/MESSAGES_TAB_FIX.md
+++ b/MESSAGES_TAB_FIX.md
@@ -1,0 +1,204 @@
+# Messages Tab Fix Documentation
+
+## Overview
+
+This document details the fix implemented for the Messages tab in Crystal's session window. The Messages tab was intended to show JSON output from Claude Code for debugging purposes but was broken and not displaying any data.
+
+## Problem Description
+
+The Messages tab in the session view was supposed to display JSON messages from Claude Code instances for debugging, but it was showing "No messages yet" even when sessions had active Claude Code conversations. The issue was that there was no mechanism to load and populate the JSON messages data.
+
+## Root Cause Analysis
+
+1. **Missing Data Flow**: The `JsonMessageView` component expected `activeSession.jsonMessages` to be populated, but this array was always empty
+2. **No Loading Mechanism**: There was no IPC handler or frontend logic to fetch JSON messages separately from regular output
+3. **Data Transformation Issue**: The existing `sessions:get-output` handler was transforming JSON messages to formatted stdout for the Output tab, losing the original JSON structure
+
+## Solution Architecture
+
+The fix implements a complete end-to-end data flow:
+
+```
+Frontend (Messages Tab) → API Layer → IPC Handler → Session Manager → Database
+```
+
+### Key Components
+
+1. **New IPC Handler**: `sessions:get-json-messages`
+2. **Frontend API Method**: `API.sessions.getJsonMessages()`
+3. **Session Store Method**: `setSessionJsonMessages()`
+4. **Auto-loading Logic**: Effect hook that loads JSON messages when switching to Messages view
+
+## Implementation Details
+
+### 1. Backend IPC Handler (`main/src/ipc/session.ts`)
+
+```typescript
+ipcMain.handle('sessions:get-json-messages', async (_event, sessionId: string) => {
+  try {
+    const outputs = await sessionManager.getSessionOutputs(sessionId);
+    
+    // Filter to only JSON messages and include timestamp
+    const jsonMessages = outputs
+      .filter(output => output.type === 'json')
+      .map(output => ({
+        ...output.data,
+        timestamp: output.timestamp.toISOString()
+      }));
+    
+    return { success: true, data: jsonMessages };
+  } catch (error) {
+    return { success: false, error: 'Failed to get JSON messages' };
+  }
+});
+```
+
+**Purpose**: Extracts and returns only JSON-type outputs from session data, preserving the original JSON structure with timestamps.
+
+### 2. Preload Script Update (`main/src/preload.ts`)
+
+```typescript
+getJsonMessages: (sessionId: string): Promise<IPCResponse> => 
+  ipcRenderer.invoke('sessions:get-json-messages', sessionId),
+```
+
+**Purpose**: Exposes the new IPC handler to the frontend through the secure preload script.
+
+### 3. Frontend API Layer (`frontend/src/utils/api.ts`)
+
+```typescript
+async getJsonMessages(sessionId: string) {
+  if (!isElectron()) throw new Error('Electron API not available');
+  return window.electronAPI.sessions.getJsonMessages(sessionId);
+}
+```
+
+**Purpose**: Provides a consistent API interface with error handling for the frontend to use.
+
+### 4. Session Store Enhancement (`frontend/src/stores/sessionStore.ts`)
+
+```typescript
+setSessionJsonMessages: (sessionId, jsonMessages) => set((state) => {
+  // Update both regular sessions and activeMainRepoSession
+  const updatedSessions = state.sessions.map(session => {
+    if (session.id === sessionId) {
+      return { ...session, jsonMessages };
+    }
+    return session;
+  });
+  
+  let updatedActiveMainRepoSession = state.activeMainRepoSession;
+  if (state.activeMainRepoSession?.id === sessionId) {
+    updatedActiveMainRepoSession = { ...state.activeMainRepoSession, jsonMessages };
+  }
+  
+  return { ...state, sessions: updatedSessions, activeMainRepoSession: updatedActiveMainRepoSession };
+})
+```
+
+**Purpose**: Updates session state with JSON messages while maintaining consistency between regular sessions and main repo sessions.
+
+### 5. Session View Hook (`frontend/src/hooks/useSessionView.ts`)
+
+```typescript
+// Load JSON messages for the Messages tab
+const loadJsonMessages = useCallback(async (sessionId: string) => {
+  try {
+    const response = await API.sessions.getJsonMessages(sessionId);
+    if (response.success) {
+      const jsonMessages = response.data || [];
+      useSessionStore.getState().setSessionJsonMessages(sessionId, jsonMessages);
+    }
+  } catch (error) {
+    console.error(`Error loading JSON messages:`, error);
+  }
+}, []);
+
+// Load JSON messages when switching to messages view
+useEffect(() => {
+  if (!activeSession || viewMode !== 'messages') return;
+  loadJsonMessages(activeSession.id);
+}, [activeSession?.id, viewMode, loadJsonMessages]);
+```
+
+**Purpose**: Automatically loads JSON messages when the user switches to the Messages tab, ensuring data is available when needed.
+
+### 6. TypeScript Definitions (`frontend/src/types/electron.d.ts`)
+
+```typescript
+interface ElectronAPI {
+  sessions: {
+    // ... other methods
+    getJsonMessages: (sessionId: string) => Promise<IPCResponse>;
+    // ... other methods
+  };
+}
+```
+
+**Purpose**: Provides type safety for the new IPC method in TypeScript.
+
+## Data Flow
+
+1. **User Action**: User clicks on "Messages" tab in session view
+2. **View Mode Change**: `viewMode` state changes to 'messages'
+3. **Effect Trigger**: useEffect hook detects the view mode change
+4. **API Call**: `loadJsonMessages()` function calls `API.sessions.getJsonMessages()`
+5. **IPC Communication**: Frontend calls the `sessions:get-json-messages` IPC handler
+6. **Data Retrieval**: Backend fetches session outputs and filters for JSON messages
+7. **Response**: Filtered JSON messages returned to frontend
+8. **State Update**: `setSessionJsonMessages()` updates the session store
+9. **UI Update**: `JsonMessageView` component re-renders with the new data
+
+## Message Structure
+
+JSON messages are formatted with the following structure:
+
+```typescript
+interface JsonMessage {
+  type: string;           // e.g., 'system', 'user', 'assistant'
+  subtype?: string;       // e.g., 'init', 'result'
+  content?: string;       // Message content
+  data?: any;            // Additional structured data
+  timestamp: string;     // ISO timestamp
+  [key: string]: any;    // Other fields from Claude Code
+}
+```
+
+## Benefits
+
+1. **Debugging Capability**: Developers can now inspect raw JSON messages from Claude Code
+2. **Performance**: JSON messages are only loaded when the Messages tab is viewed
+3. **Real-time**: Messages are loaded fresh each time the tab is accessed
+4. **Type Safety**: Full TypeScript support for the new functionality
+5. **Consistency**: Follows existing patterns in the codebase
+
+## Testing
+
+The fix was tested by:
+
+1. **Type Checking**: `pnpm typecheck` passes without errors
+2. **Compilation**: `pnpm build:main` succeeds
+3. **Runtime Testing**: Application starts successfully in development mode
+4. **Integration**: IPC handlers are properly registered and accessible
+
+## Files Modified
+
+- `main/src/ipc/session.ts` - Added new IPC handler
+- `main/src/preload.ts` - Exposed new method to frontend
+- `frontend/src/utils/api.ts` - Added API method
+- `frontend/src/stores/sessionStore.ts` - Added state management method
+- `frontend/src/hooks/useSessionView.ts` - Added loading logic
+- `frontend/src/types/electron.d.ts` - Added TypeScript definitions
+
+## Future Enhancements
+
+Potential improvements could include:
+
+1. **Caching**: Cache JSON messages to avoid repeated API calls
+2. **Real-time Updates**: Listen for new JSON messages and update the tab live
+3. **Filtering**: Add filtering/search capabilities within the Messages tab
+4. **Export**: Allow exporting JSON messages for external debugging tools
+
+## Conclusion
+
+The Messages tab fix provides a complete solution for debugging Claude Code sessions by making the raw JSON messages accessible through a clean, type-safe interface. The implementation follows Crystal's architectural patterns and maintains consistency with existing code.

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -266,6 +266,28 @@ export const useSessionView = (
     }
   }, [activeSession?.status, isWaitingForFirstOutput]);
 
+  // Load JSON messages for the Messages tab
+  const loadJsonMessages = useCallback(async (sessionId: string) => {
+    try {
+      console.log(`[loadJsonMessages] Loading JSON messages for session: ${sessionId}`);
+      const response = await API.sessions.getJsonMessages(sessionId);
+      
+      if (!response.success) {
+        console.error(`[loadJsonMessages] Failed to load JSON messages:`, response.error);
+        return;
+      }
+      
+      const jsonMessages = response.data || [];
+      console.log(`[loadJsonMessages] Received ${jsonMessages.length} JSON messages for session ${sessionId}`);
+      
+      // Update the session store with JSON messages
+      useSessionStore.getState().setSessionJsonMessages(sessionId, jsonMessages);
+      
+    } catch (error) {
+      console.error(`[loadJsonMessages] Error loading JSON messages for session ${sessionId}:`, error);
+    }
+  }, []);
+
   useEffect(() => {
     if (!activeSessionId) return;
     const unsubscribe = useSessionStore.subscribe((state) => {
@@ -948,6 +970,14 @@ export const useSessionView = (
   useEffect(() => {
     setUnreadActivity({ output: false, messages: false, changes: false, terminal: false, editor: false });
   }, [activeSessionId]);
+
+  // Load JSON messages when switching to messages view
+  useEffect(() => {
+    if (!activeSession || viewMode !== 'messages') return;
+    
+    console.log(`[useSessionView] Loading JSON messages for session ${activeSession.id} due to view mode change`);
+    loadJsonMessages(activeSession.id);
+  }, [activeSession?.id, viewMode, loadJsonMessages]);
 
 
   useEffect(() => {

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -25,6 +25,7 @@ interface SessionStore {
   addSessionOutput: (output: SessionOutput) => void;
   setSessionOutput: (sessionId: string, output: string) => void;
   setSessionOutputs: (sessionId: string, outputs: SessionOutput[]) => void;
+  setSessionJsonMessages: (sessionId: string, jsonMessages: any[]) => void;
   clearSessionOutput: (sessionId: string) => void;
   addScriptOutput: (output: { sessionId: string; type: 'stdout' | 'stderr'; data: string }) => void;
   clearScriptOutput: (sessionId: string) => void;
@@ -319,6 +320,32 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     if (state.activeMainRepoSession && state.activeMainRepoSession.id === sessionId) {
       console.log(`[SessionStore] Also updating activeMainRepoSession`);
       updatedActiveMainRepoSession = { ...state.activeMainRepoSession, output: stdOutputs, jsonMessages };
+    }
+    
+    return {
+      ...state,
+      sessions: updatedSessions,
+      activeMainRepoSession: updatedActiveMainRepoSession
+    };
+  }),
+  
+  setSessionJsonMessages: (sessionId, jsonMessages) => set((state) => {
+    console.log(`[SessionStore] Setting ${jsonMessages.length} JSON messages for session ${sessionId}`);
+    
+    // Update the sessions array
+    const updatedSessions = state.sessions.map(session => {
+      if (session.id === sessionId) {
+        console.log(`[SessionStore] Updating session ${sessionId} with JSON messages`);
+        return { ...session, jsonMessages };
+      }
+      return session;
+    });
+    
+    // Also update activeMainRepoSession if it matches
+    let updatedActiveMainRepoSession = state.activeMainRepoSession;
+    if (state.activeMainRepoSession && state.activeMainRepoSession.id === sessionId) {
+      console.log(`[SessionStore] Also updating activeMainRepoSession with JSON messages`);
+      updatedActiveMainRepoSession = { ...state.activeMainRepoSession, jsonMessages };
     }
     
     return {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -43,6 +43,7 @@ interface ElectronAPI {
     continue: (sessionId: string, prompt?: string, model?: string) => Promise<IPCResponse>;
     getOutput: (sessionId: string) => Promise<IPCResponse>;
     getConversation: (sessionId: string) => Promise<IPCResponse>;
+    getJsonMessages: (sessionId: string) => Promise<IPCResponse>;
     markViewed: (sessionId: string) => Promise<IPCResponse>;
     stop: (sessionId: string) => Promise<IPCResponse>;
     

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -68,6 +68,11 @@ export class API {
       return window.electronAPI.sessions.getConversation(sessionId);
     },
 
+    async getJsonMessages(sessionId: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.getJsonMessages(sessionId);
+    },
+
     async markViewed(sessionId: string) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.sessions.markViewed(sessionId);

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -444,6 +444,28 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
     }
   });
 
+  ipcMain.handle('sessions:get-json-messages', async (_event, sessionId: string) => {
+    try {
+      console.log(`[IPC] sessions:get-json-messages called for session: ${sessionId}`);
+      const outputs = await sessionManager.getSessionOutputs(sessionId);
+      console.log(`[IPC] Retrieved ${outputs.length} total outputs for session ${sessionId}`);
+      
+      // Filter to only JSON messages and include timestamp
+      const jsonMessages = outputs
+        .filter(output => output.type === 'json')
+        .map(output => ({
+          ...output.data,
+          timestamp: output.timestamp.toISOString()
+        }));
+      
+      console.log(`[IPC] Found ${jsonMessages.length} JSON messages for session ${sessionId}`);
+      return { success: true, data: jsonMessages };
+    } catch (error) {
+      console.error('Failed to get JSON messages:', error);
+      return { success: false, error: 'Failed to get JSON messages' };
+    }
+  });
+
   ipcMain.handle('sessions:mark-viewed', async (_event, sessionId: string) => {
     try {
       await sessionManager.markSessionAsViewed(sessionId);

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -45,6 +45,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     continue: (sessionId: string, prompt?: string, model?: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:continue', sessionId, prompt, model),
     getOutput: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-output', sessionId),
     getConversation: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-conversation', sessionId),
+    getJsonMessages: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-json-messages', sessionId),
     markViewed: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:mark-viewed', sessionId),
     stop: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:stop', sessionId),
     


### PR DESCRIPTION
## Summary

Restores functionality to the Messages tab in session windows, which was previously broken and not displaying any data. The tab now properly loads and displays JSON messages from Claude Code sessions for debugging purposes.

## Key Changes

- **New IPC Handler**: Added `sessions:get-json-messages` to filter and return JSON outputs from session data
- **Frontend Integration**: Implemented API layer, session store methods, and auto-loading logic
- **Type Safety**: Updated TypeScript definitions for the new functionality
- **Documentation**: Added comprehensive implementation guide (`MESSAGES_TAB_FIX.md`)

## Technical Implementation

### Backend
- New IPC handler in `main/src/ipc/session.ts` that filters session outputs for JSON messages
- Exposes method through preload script for secure frontend access

### Frontend
- API layer method for consistent error handling
- Session store integration to manage JSON message state
- Auto-loading effect when switching to Messages tab
- TypeScript definitions for type safety

## Current Status

✅ **Working**: Messages tab now populates with Claude Code JSON data  
⚠️ **Note**: Message classification may not be 100% accurate currently  
🔧 **Future**: Consider adding dev-only toggle if needed, but stable for general use  

## Benefits

- **Debugging**: Developers can inspect raw JSON messages from Claude Code sessions
- **Performance**: Messages only loaded when tab is accessed
- **Type Safety**: Full TypeScript support
- **Documentation**: Comprehensive implementation guide for future development

## Test Plan

- [x] Type checking passes (`pnpm typecheck`)
- [x] Main process builds successfully (`pnpm build:main`)
- [x] Application starts in development mode
- [x] Messages tab loads data when clicked
- [x] JSON messages display with proper formatting

## Files Changed

- `main/src/ipc/session.ts` - New IPC handler
- `main/src/preload.ts` - Exposed new method
- `frontend/src/utils/api.ts` - API method
- `frontend/src/stores/sessionStore.ts` - State management
- `frontend/src/hooks/useSessionView.ts` - Loading logic
- `frontend/src/types/electron.d.ts` - TypeScript definitions
- `MESSAGES_TAB_FIX.md` - Implementation documentation

This fix enables debugging of Claude Code sessions and provides a foundation for future debugging features.