### PR TITLE
feat: Add Project Dashboard - replaces non-worktree session creation

### DIFF
--- a/frontend/src/components/DraggableProjectTreeView.tsx
+++ b/frontend/src/components/DraggableProjectTreeView.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { ChevronRight, ChevronDown, Folder as FolderIcon, FolderOpen, Plus, Settings, GripVertical, Archive } from 'lucide-react';
 import { useSessionStore } from '../stores/sessionStore';
 import { useErrorStore } from '../stores/errorStore';
+import { useNavigationStore } from '../stores/navigationStore';
 import { SessionListItem } from './SessionListItem';
 import { CreateSessionDialog } from './CreateSessionDialog';
-import { MainBranchWarningDialog } from './MainBranchWarningDialog';
 import ProjectSettings from './ProjectSettings';
 import { EmptyState } from './EmptyState';
 import { LoadingSpinner } from './LoadingSpinner';
@@ -46,9 +46,6 @@ export function DraggableProjectTreeView() {
   const [showAddProjectDialog, setShowAddProjectDialog] = useState(false);
   const [newProject, setNewProject] = useState({ name: '', path: '', buildScript: '', runScript: '' });
   const activeSessionId = useSessionStore((state) => state.activeSessionId);
-  const [showMainBranchWarning, setShowMainBranchWarning] = useState(false);
-  const [pendingMainBranchProject, setPendingMainBranchProject] = useState<Project | null>(null);
-  const [detectedMainBranch, setDetectedMainBranch] = useState<string>('main');
   const [detectedBranchForNewProject, setDetectedBranchForNewProject] = useState<string | null>(null);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
   const [selectedProjectForFolder, setSelectedProjectForFolder] = useState<Project | null>(null);
@@ -606,58 +603,11 @@ export function DraggableProjectTreeView() {
   };
 
   const handleProjectClick = async (project: Project) => {
-    // Check if we should show the warning
-    const warningKey = `mainBranchWarning_${project.id}`;
-    const hasShownWarning = localStorage.getItem(warningKey);
-    
-    if (!hasShownWarning) {
-      // Fetch the current branch before showing warning
-      try {
-        const response = await window.electronAPI.git.detectBranch(project.path);
-        if (response.success && response.data) {
-          setDetectedMainBranch(response.data);
-        } else {
-          setDetectedMainBranch('main');
-        }
-      } catch (error) {
-        console.error('Failed to detect branch:', error);
-        setDetectedMainBranch('main');
-      }
-      
-      // Show warning dialog
-      setPendingMainBranchProject(project);
-      setShowMainBranchWarning(true);
-    } else {
-      // Proceed directly
-      await openMainRepoSession(project);
-    }
+    // Navigate to the project dashboard
+    const { navigateToProjectDashboard } = useNavigationStore.getState();
+    navigateToProjectDashboard(project.id);
   };
   
-  const openMainRepoSession = async (project: Project) => {
-    try {
-      // Get or create the main repo session
-      const response = await API.sessions.getOrCreateMainRepoSession(project.id);
-      
-      if (response.success && response.data) {
-        // Navigate to the main repo session
-        const session = response.data;
-        useSessionStore.getState().setActiveSession(session.id);
-        
-        // Don't expand the project - main repo sessions are accessed via folder click only
-      } else {
-        showError({
-          title: 'Failed to open main repository session',
-          error: response.error || 'Unknown error occurred'
-        });
-      }
-    } catch (error: any) {
-      console.error('Error handling project click:', error);
-      showError({
-        title: 'Failed to open main repository session',
-        error: error.message || 'Unknown error occurred'
-      });
-    }
-  };
 
   const handleCreateSession = (project: Project) => {
     // Just show the dialog for any project
@@ -1565,7 +1515,10 @@ export function DraggableProjectTreeView() {
                             <div
                               key={session.id}
                               className="cursor-pointer"
-                              onClick={() => useSessionStore.getState().setActiveSession(session.id)}
+                              onClick={() => {
+                                useSessionStore.getState().setActiveSession(session.id);
+                                useNavigationStore.getState().navigateToSessions();
+                              }}
                             >
                               <SessionListItem 
                                 session={session}
@@ -1741,26 +1694,6 @@ export function DraggableProjectTreeView() {
         </div>
       )}
       
-      {/* Main Branch Warning Dialog */}
-      {pendingMainBranchProject && (
-        <MainBranchWarningDialog
-          isOpen={showMainBranchWarning}
-          onClose={() => {
-            setShowMainBranchWarning(false);
-            setPendingMainBranchProject(null);
-          }}
-          onContinue={() => {
-            setShowMainBranchWarning(false);
-            if (pendingMainBranchProject) {
-              openMainRepoSession(pendingMainBranchProject);
-            }
-            setPendingMainBranchProject(null);
-          }}
-          projectName={pendingMainBranchProject.name}
-          projectId={pendingMainBranchProject.id}
-          mainBranch={detectedMainBranch}
-        />
-      )}
       
       {/* Create Folder Dialog */}
       {showCreateFolderDialog && selectedProjectForFolder && (

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -1,0 +1,363 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { RefreshCw, GitBranch, AlertCircle, CheckCircle, Clock, GitPullRequest, Loader2, XCircle, Filter } from 'lucide-react';
+import { API } from '../utils/api';
+import type { ProjectDashboardData, SessionBranchInfo } from '../types/projectDashboard';
+import { formatDistanceToNow } from '../utils/timestampUtils';
+import { dashboardCache } from '../utils/dashboardCache';
+import { debounce } from '../utils/debounce';
+import { ProjectDashboardSkeleton } from './ProjectDashboardSkeleton';
+import { useSessionStore } from '../stores/sessionStore';
+import { useNavigationStore } from '../stores/navigationStore';
+import { MultiOriginStatus } from './dashboard/MultiOriginStatus';
+import { StatusSummaryCards } from './dashboard/StatusSummaryCards';
+
+interface ProjectDashboardProps {
+  projectId: number;
+  projectName: string;
+}
+
+export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ projectId, projectName }) => {
+  const [dashboardData, setDashboardData] = useState<ProjectDashboardData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
+  const [filterType, setFilterType] = useState<'all' | 'stale' | 'changes' | 'pr'>('all');
+
+  const fetchDashboardData = useCallback(async (useCache: boolean = true) => {
+    // Check cache first if not forcing refresh
+    if (useCache) {
+      const cachedData = dashboardCache.get(projectId);
+      if (cachedData) {
+        setDashboardData(cachedData);
+        setLastRefreshTime(new Date(Date.now() - 30000)); // Show it was from cache
+        return;
+      }
+    }
+    
+    setIsLoading(!dashboardData); // Only show loading on initial load
+    setIsRefreshing(!!dashboardData); // Show refreshing if we already have data
+    setError(null);
+    
+    try {
+      const response = await API.dashboard.getProjectStatus(projectId);
+      
+      if (response.success && response.data) {
+        setDashboardData(response.data);
+        setLastRefreshTime(new Date());
+        // Cache the data
+        dashboardCache.set(projectId, response.data);
+      } else {
+        setError(response.error || 'Failed to fetch project status');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error occurred');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, [projectId, dashboardData]);
+
+  // Debounced refresh function
+  const debouncedRefresh = useMemo(
+    () => debounce(() => {
+      dashboardCache.invalidate(projectId);
+      fetchDashboardData(false);
+    }, 500),
+    [projectId, fetchDashboardData]
+  );
+
+  useEffect(() => {
+    // Clear previous data when switching projects to show skeleton
+    setDashboardData(null);
+    setError(null);
+    fetchDashboardData();
+  }, [projectId]); // Only refetch when projectId changes
+
+  // Memoize grouped sessions by base branch (for future use)
+  // const groupedSessions = useMemo(() => {
+  //   if (!dashboardData) return new Map();
+  //   
+  //   const groups = new Map<string, SessionBranchInfo[]>();
+  //   dashboardData.sessionBranches.forEach(session => {
+  //     const baseBranch = session.baseBranch || 'unknown';
+  //     if (!groups.has(baseBranch)) {
+  //       groups.set(baseBranch, []);
+  //     }
+  //     groups.get(baseBranch)!.push(session);
+  //   });
+  //   
+  //   return groups;
+  // }, [dashboardData?.sessionBranches]);
+
+  const getMainBranchStatusIcon = (status: string) => {
+    switch (status) {
+      case 'up-to-date':
+        return <CheckCircle className="w-4 h-4 text-green-500" />;
+      case 'behind':
+        return <AlertCircle className="w-4 h-4 text-yellow-500" />;
+      case 'ahead':
+        return <Clock className="w-4 h-4 text-blue-500" />;
+      case 'diverged':
+        return <AlertCircle className="w-4 h-4 text-red-500" />;
+      default:
+        return null;
+    }
+  };
+
+  const getMainBranchStatusText = () => {
+    if (!dashboardData) return '';
+    
+    const { status, aheadCount, behindCount } = dashboardData.mainBranchStatus;
+    
+    switch (status) {
+      case 'up-to-date':
+        return 'Up to date with origin';
+      case 'behind':
+        return `Behind origin by ${behindCount} commit${behindCount !== 1 ? 's' : ''}`;
+      case 'ahead':
+        return `Ahead of origin by ${aheadCount} commit${aheadCount !== 1 ? 's' : ''}`;
+      case 'diverged':
+        return `Diverged: ${aheadCount} ahead, ${behindCount} behind`;
+      default:
+        return 'Unknown status';
+    }
+  };
+
+  const renderSessionRow = useCallback((session: SessionBranchInfo) => {
+    const staleClass = session.isStale ? 'bg-yellow-50 dark:bg-yellow-900/20' : '';
+    
+    const handleSessionClick = () => {
+      useSessionStore.getState().setActiveSession(session.sessionId);
+      useNavigationStore.getState().navigateToSessions();
+    };
+    
+    return (
+      <tr key={session.sessionId} className={`hover:bg-gray-50 dark:hover:bg-gray-800 ${staleClass} cursor-pointer`} onClick={handleSessionClick}>
+        <td className="px-4 py-3 text-sm">
+          <div className="flex items-center gap-2">
+            <GitBranch className="w-4 h-4 text-gray-400" />
+            <div>
+              <div className="font-medium text-gray-900 dark:text-gray-100">{session.sessionName}</div>
+              <div className="text-gray-500 dark:text-gray-400 text-xs">{session.branchName}</div>
+            </div>
+          </div>
+        </td>
+        <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+          <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+            {session.baseBranch}
+          </code>
+        </td>
+        <td className="px-4 py-3 text-sm">
+          {session.isStale ? (
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4 text-yellow-600" />
+              <span className="text-yellow-700 dark:text-yellow-400">
+                Stale {session.staleSince && `since ${formatDistanceToNow(session.staleSince)}`}
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              <span className="text-green-700 dark:text-green-400">Current</span>
+            </div>
+          )}
+        </td>
+        <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+          <div className="flex gap-3 text-xs">
+            {session.commitsAhead > 0 && (
+              <span className="text-blue-600 dark:text-blue-400">+{session.commitsAhead}</span>
+            )}
+            {session.commitsBehind > 0 && (
+              <span className="text-orange-600 dark:text-orange-400">-{session.commitsBehind}</span>
+            )}
+            {session.commitsAhead === 0 && session.commitsBehind === 0 && (
+              <span className="text-gray-400">—</span>
+            )}
+          </div>
+        </td>
+        <td className="px-4 py-3 text-sm">
+          {session.hasUncommittedChanges && (
+            <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+              <AlertCircle className="w-3 h-3" />
+              <span className="text-xs">Uncommitted</span>
+            </span>
+          )}
+        </td>
+        <td className="px-4 py-3 text-sm">
+          {session.pullRequest ? (
+            <a
+              href={session.pullRequest.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 dark:text-blue-400"
+            >
+              <GitPullRequest className="w-4 h-4" />
+              <span>#{session.pullRequest.number}</span>
+              {session.pullRequest.state === 'open' && (
+                <span className="inline-block w-2 h-2 bg-green-500 rounded-full"></span>
+              )}
+              {session.pullRequest.state === 'closed' && (
+                <XCircle className="w-3 h-3 text-red-500" />
+              )}
+              {session.pullRequest.state === 'merged' && (
+                <CheckCircle className="w-3 h-3 text-purple-500" />
+              )}
+            </a>
+          ) : (
+            <span className="text-gray-400">—</span>
+          )}
+        </td>
+      </tr>
+    );
+  }, []);
+
+  // Filter sessions based on selected filter
+  const filteredSessions = useMemo(() => {
+    if (!dashboardData) return [];
+    
+    switch (filterType) {
+      case 'stale':
+        return dashboardData.sessionBranches.filter(s => s.isStale);
+      case 'changes':
+        return dashboardData.sessionBranches.filter(s => s.hasUncommittedChanges);
+      case 'pr':
+        return dashboardData.sessionBranches.filter(s => s.pullRequest);
+      default:
+        return dashboardData.sessionBranches;
+    }
+  }, [dashboardData, filterType]);
+
+  if (error) {
+    return (
+      <div className="p-6 bg-red-50 dark:bg-red-900/20 rounded-lg">
+        <div className="flex items-center gap-2 text-red-700 dark:text-red-400">
+          <AlertCircle className="w-5 h-5" />
+          <span className="font-medium">Error loading dashboard</span>
+        </div>
+        <p className="mt-1 text-sm text-red-600 dark:text-red-300">{error}</p>
+        <button
+          onClick={() => fetchDashboardData(false)}
+          className="mt-3 px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading && !dashboardData) {
+    return <ProjectDashboardSkeleton />;
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 flex flex-col h-full">
+      <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Project Dashboard
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Git status for {dashboardData?.projectName || projectName}
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            {lastRefreshTime && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Updated {formatDistanceToNow(lastRefreshTime)}
+              </span>
+            )}
+            <button
+              onClick={debouncedRefresh}
+              disabled={isLoading || isRefreshing}
+              className="inline-flex items-center gap-2 px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-800 
+                       text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 
+                       disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {(isLoading || isRefreshing) ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <RefreshCw className="w-4 h-4" />
+              )}
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {dashboardData ? (
+        <div className="p-6 flex-1 flex flex-col overflow-hidden">
+          {/* Multi-Origin Status */}
+          <MultiOriginStatus 
+            mainBranch={dashboardData.mainBranch}
+            mainBranchStatus={dashboardData.mainBranchStatus}
+            remotes={dashboardData.remotes}
+            onReviewUpdates={() => console.log('Review updates clicked')}
+          />
+          
+          {/* Status Summary Cards */}
+          <StatusSummaryCards sessions={dashboardData.sessionBranches} />
+
+          {/* Session Branches Table */}
+          {dashboardData.sessionBranches.length > 0 ? (
+            <div className="flex-1 flex flex-col overflow-hidden">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Session Branches ({filteredSessions.length} of {dashboardData.sessionBranches.length})
+                </h3>
+                <div className="flex items-center gap-2">
+                  <Filter className="w-4 h-4 text-gray-400" />
+                  <select
+                    value={filterType}
+                    onChange={(e) => setFilterType(e.target.value as typeof filterType)}
+                    className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                  >
+                    <option value="all">All Sessions</option>
+                    <option value="stale">Stale Only</option>
+                    <option value="changes">With Changes</option>
+                    <option value="pr">With PR</option>
+                  </select>
+                </div>
+              </div>
+              <div className="flex-1 overflow-x-auto overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                  <thead className="bg-gray-50 dark:bg-gray-800">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Session
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Base Branch
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Status
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Commits
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Changes
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Pull Request
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+                    {filteredSessions.map(renderSessionRow)}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+              <GitBranch className="w-12 h-12 mx-auto mb-3 text-gray-300 dark:text-gray-600" />
+              <p>No active session branches</p>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/frontend/src/components/ProjectDashboardSkeleton.tsx
+++ b/frontend/src/components/ProjectDashboardSkeleton.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+export const ProjectDashboardSkeleton: React.FC = () => {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 animate-pulse">
+      {/* Header Skeleton */}
+      <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="h-6 w-48 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
+            <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+            <div className="h-8 w-20 bg-gray-200 dark:bg-gray-700 rounded"></div>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {/* Main Branch Status Skeleton */}
+        <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="w-5 h-5 bg-gray-300 dark:bg-gray-600 rounded"></div>
+              <div>
+                <div className="h-5 w-36 bg-gray-200 dark:bg-gray-700 rounded mb-2"></div>
+                <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Table Header Skeleton */}
+        <div className="mb-3">
+          <div className="h-4 w-40 bg-gray-200 dark:bg-gray-700 rounded"></div>
+        </div>
+
+        {/* Table Skeleton */}
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                {[1, 2, 3, 4, 5, 6].map((i) => (
+                  <th key={i} className="px-4 py-3">
+                    <div className="h-3 w-16 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+              {[1, 2, 3].map((row) => (
+                <tr key={row}>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <div className="w-4 h-4 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                      <div>
+                        <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-1"></div>
+                        <div className="h-3 w-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-12 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/MultiOriginStatus.tsx
+++ b/frontend/src/components/dashboard/MultiOriginStatus.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { GitBranch, AlertCircle, CheckCircle, Clock, ArrowRight, GitFork } from 'lucide-react';
+import type { RemoteStatus, MainBranchStatus } from '../../types/projectDashboard';
+
+interface MultiOriginStatusProps {
+  mainBranch: string;
+  mainBranchStatus: MainBranchStatus;
+  remotes?: RemoteStatus[];
+  onReviewUpdates?: () => void;
+}
+
+export const MultiOriginStatus: React.FC<MultiOriginStatusProps> = ({
+  mainBranch,
+  mainBranchStatus,
+  remotes = [],
+  onReviewUpdates
+}) => {
+  // Find upstream and origin remotes
+  const upstream = remotes.find(r => r.isUpstream || r.name === 'upstream');
+  const origin = remotes.find(r => !r.isUpstream && r.name === 'origin');
+  const hasMultipleRemotes = remotes.length > 1;
+  
+  // Check if any updates are needed
+  const upstreamNeedsUpdate = upstream && upstream.status !== 'up-to-date';
+  const originNeedsUpdate = origin && origin.status !== 'up-to-date';
+  const localNeedsUpdate = mainBranchStatus.status !== 'up-to-date';
+  const hasUpdatesNeeded = upstreamNeedsUpdate || originNeedsUpdate || localNeedsUpdate;
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'up-to-date':
+        return <CheckCircle className="w-4 h-4 text-green-500" />;
+      case 'behind':
+        return <AlertCircle className="w-4 h-4 text-yellow-500" />;
+      case 'ahead':
+        return <Clock className="w-4 h-4 text-blue-500" />;
+      case 'diverged':
+        return <AlertCircle className="w-4 h-4 text-red-500" />;
+      default:
+        return null;
+    }
+  };
+
+  const getStatusText = (remote: RemoteStatus) => {
+    switch (remote.status) {
+      case 'up-to-date':
+        return 'Up to date';
+      case 'behind':
+        return `${remote.behindCount} behind`;
+      case 'ahead':
+        return `${remote.aheadCount} ahead`;
+      case 'diverged':
+        return `${remote.aheadCount}↑ ${remote.behindCount}↓`;
+      default:
+        return 'Unknown';
+    }
+  };
+
+  const getLocalStatusText = () => {
+    const { status, aheadCount = 0, behindCount = 0 } = mainBranchStatus;
+    switch (status) {
+      case 'up-to-date':
+        return 'Synced with origin';
+      case 'behind':
+        return `${behindCount} behind origin`;
+      case 'ahead':
+        return `${aheadCount} ahead of origin`;
+      case 'diverged':
+        return `${aheadCount}↑ ${behindCount}↓`;
+      default:
+        return 'Unknown status';
+    }
+  };
+
+  if (!hasMultipleRemotes) {
+    // Single remote view (original view)
+    return (
+      <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <GitBranch className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+            <div>
+              <h3 className="font-medium text-gray-900 dark:text-gray-100">
+                Main Branch ({mainBranch})
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2 mt-1">
+                {getStatusIcon(mainBranchStatus.status)}
+                {getLocalStatusText()}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Multi-remote cascade view
+  return (
+    <div className="mb-6 space-y-3">
+      {/* Multi-Origin Status Flow */}
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-50 dark:bg-gray-800 px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">Git Remote Status</h3>
+        </div>
+        
+        <div className="p-4">
+          <div className="flex items-center gap-3">
+            
+            {/* Upstream Status */}
+            {upstream && (
+              <>
+                <div className="flex-1 bg-purple-50 dark:bg-purple-900/20 rounded-lg p-3 border border-purple-200 dark:border-purple-800">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="flex items-center gap-2 mb-1">
+                        <GitBranch className="w-4 h-4 text-purple-600 dark:text-purple-400" />
+                        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                          {upstream.name}/{upstream.branch}
+                        </span>
+                      </div>
+                      <div className="text-xs text-gray-600 dark:text-gray-400">Source repository</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {upstream.status !== 'up-to-date' && (
+                        <span className="text-xs font-medium text-purple-700 dark:text-purple-300">
+                          {getStatusText(upstream)}
+                        </span>
+                      )}
+                      {getStatusIcon(upstream.status)}
+                    </div>
+                  </div>
+                </div>
+                
+                <ArrowRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
+              </>
+            )}
+          
+            {/* Origin/Fork Status */}
+            {origin && (
+              <>
+                <div className="flex-1 bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="flex items-center gap-2 mb-1">
+                        <GitBranch className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+                        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                          {origin.name}/{origin.branch}
+                        </span>
+                        {origin.isFork && (
+                          <span className="inline-flex items-center gap-1 text-xs bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-300 px-1.5 py-0.5 rounded">
+                            <GitFork className="w-3 h-3" />
+                            <span>fork</span>
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-600 dark:text-gray-400">Your remote</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {origin.status !== 'up-to-date' && (
+                        <span className="text-xs font-medium text-blue-700 dark:text-blue-300">
+                          {getStatusText(origin)}
+                        </span>
+                      )}
+                      {getStatusIcon(origin.status)}
+                    </div>
+                  </div>
+                </div>
+                
+                <ArrowRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
+              </>
+            )}
+          
+            {/* Local Main Status */}
+            <div className="flex-1 bg-gray-50 dark:bg-gray-800 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="flex items-center gap-2 mb-1">
+                    <GitBranch className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      {mainBranch}
+                    </span>
+                    <span className="text-xs bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded">
+                      local
+                    </span>
+                  </div>
+                  <div className="text-xs text-gray-600 dark:text-gray-400">Base for sessions</div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {mainBranchStatus.status !== 'up-to-date' && (
+                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                      {getLocalStatusText()}
+                    </span>
+                  )}
+                  {getStatusIcon(mainBranchStatus.status)}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        {/* Action Bar - Shows when updates are needed */}
+        {hasUpdatesNeeded && (
+          <div className="bg-amber-50 dark:bg-amber-900/20 border-t border-amber-200 dark:border-amber-800 px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <AlertCircle className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+                <span className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                  Updates available in the cascade
+                </span>
+              </div>
+              {onReviewUpdates && (
+                <button 
+                  onClick={onReviewUpdates}
+                  className="text-sm bg-amber-600 hover:bg-amber-700 text-white px-3 py-1.5 rounded font-medium transition-colors"
+                >
+                  Review Updates →
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+        
+        {/* Flow Legend */}
+        <div className="bg-gray-50 dark:bg-gray-800 px-4 py-2 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-6 text-xs text-gray-600 dark:text-gray-400">
+            <div className="flex items-center gap-2">
+              <CheckCircle className="w-3 h-3 text-green-500" />
+              <span>Synced</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-3 h-3 text-yellow-500" />
+              <span>Behind</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Clock className="w-3 h-3 text-blue-500" />
+              <span>Ahead</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-3 h-3 text-red-500" />
+              <span>Diverged</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/StatusSummaryCards.tsx
+++ b/frontend/src/components/dashboard/StatusSummaryCards.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import type { SessionBranchInfo } from '../../types/projectDashboard';
+
+interface StatusSummaryCardsProps {
+  sessions: SessionBranchInfo[];
+}
+
+export const StatusSummaryCards: React.FC<StatusSummaryCardsProps> = ({ sessions }) => {
+  const upToDateCount = sessions.filter(s => !s.isStale).length;
+  const staleCount = sessions.filter(s => s.isStale).length;
+  const needsAttentionCount = sessions.filter(s => s.hasUncommittedChanges).length;
+
+  return (
+    <div className="grid grid-cols-3 gap-3 mb-6">
+      <div className="bg-white dark:bg-gray-900 p-4 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Up to date</span>
+            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+          </div>
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {upToDateCount}
+            <span className="text-sm font-normal text-gray-500 dark:text-gray-400">/{sessions.length}</span>
+          </div>
+        </div>
+      </div>
+      <div className="bg-white dark:bg-gray-900 p-4 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Stale</span>
+            <div className="w-2 h-2 bg-yellow-500 rounded-full"></div>
+          </div>
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {staleCount}
+          </div>
+        </div>
+      </div>
+      <div className="bg-white dark:bg-gray-900 p-4 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Changes</span>
+            <div className="w-2 h-2 bg-orange-500 rounded-full"></div>
+          </div>
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {needsAttentionCount}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/session/SessionHeader.tsx
+++ b/frontend/src/components/session/SessionHeader.tsx
@@ -29,6 +29,7 @@ interface SessionHeaderProps {
     changes: boolean;
     terminal: boolean;
     editor: boolean;
+    dashboard: boolean;
   };
   setUnreadActivity: (activity: any) => void;
 }

--- a/frontend/src/components/session/ViewTabs.tsx
+++ b/frontend/src/components/session/ViewTabs.tsx
@@ -10,6 +10,7 @@ interface ViewTabsProps {
     changes: boolean;
     terminal: boolean;
     editor: boolean;
+    dashboard: boolean;
   };
   setUnreadActivity: (activity: any) => void;
   jsonMessagesCount: number;
@@ -30,6 +31,7 @@ export const ViewTabs: React.FC<ViewTabsProps> = ({
     { mode: 'changes', label: 'View Diff', activity: unreadActivity.changes },
     { mode: 'terminal', label: 'Terminal', activity: unreadActivity.terminal, status: isTerminalRunning },
     { mode: 'editor', label: 'File Editor', activity: unreadActivity.editor },
+    { mode: 'dashboard', label: 'Dashboard', activity: unreadActivity.dashboard },
   ];
 
   return (

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -7,7 +7,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Session, GitCommands, GitErrorDetails } from '../types/session';
 import { createVisibilityAwareInterval } from '../utils/performanceUtils';
 
-export type ViewMode = 'output' | 'messages' | 'changes' | 'terminal' | 'editor';
+export type ViewMode = 'output' | 'messages' | 'changes' | 'terminal' | 'editor' | 'dashboard';
 
 export const useSessionView = (
   activeSession: Session | undefined,
@@ -31,6 +31,7 @@ export const useSessionView = (
     changes: false,
     terminal: false,
     editor: false,
+    dashboard: false,
   });
   const [isEditingName, setIsEditingName] = useState(false);
   const [editName, setEditName] = useState('');
@@ -331,6 +332,7 @@ export const useSessionView = (
       changes: false,
       terminal: false,
       editor: false,
+      dashboard: false,
     });
     
     // Clear terminal immediately when session changes
@@ -946,7 +948,7 @@ export const useSessionView = (
   }, [activeSession?.status, activeSession?.runStartedAt, activeSessionId]);
 
   useEffect(() => {
-    setUnreadActivity({ output: false, messages: false, changes: false, terminal: false, editor: false });
+    setUnreadActivity({ output: false, messages: false, changes: false, terminal: false, editor: false, dashboard: false });
   }, [activeSessionId]);
 
 

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+interface NavigationState {
+  activeView: 'sessions' | 'dashboard';
+  activeProjectId: number | null;
+  
+  // Actions
+  setActiveView: (view: 'sessions' | 'dashboard') => void;
+  setActiveProjectId: (projectId: number | null) => void;
+  navigateToProjectDashboard: (projectId: number) => void;
+  navigateToSessions: () => void;
+}
+
+export const useNavigationStore = create<NavigationState>((set) => ({
+  activeView: 'sessions',
+  activeProjectId: null,
+  
+  setActiveView: (view) => set({ activeView: view }),
+  
+  setActiveProjectId: (projectId) => set({ activeProjectId: projectId }),
+  
+  navigateToProjectDashboard: (projectId) => set({ 
+    activeView: 'dashboard', 
+    activeProjectId: projectId 
+  }),
+  
+  navigateToSessions: () => set({ 
+    activeView: 'sessions'
+  }),
+}));

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -113,6 +113,11 @@ interface ElectronAPI {
     listBranches: (projectId: string) => Promise<IPCResponse>;
   };
 
+  // Dashboard
+  dashboard: {
+    getProjectStatus: (projectId: number) => Promise<IPCResponse>;
+  };
+
   // Git operations
   git: {
     detectBranch: (path: string) => Promise<IPCResponse<string>>;

--- a/frontend/src/types/projectDashboard.ts
+++ b/frontend/src/types/projectDashboard.ts
@@ -1,0 +1,53 @@
+export interface MainBranchStatus {
+  status: 'up-to-date' | 'behind' | 'ahead' | 'diverged';
+  aheadCount?: number;
+  behindCount?: number;
+  lastFetched: string;
+}
+
+export interface RemoteStatus {
+  name: string;
+  url: string;
+  branch: string;
+  status: 'up-to-date' | 'behind' | 'ahead' | 'diverged';
+  aheadCount: number;
+  behindCount: number;
+  isUpstream?: boolean;
+  isFork?: boolean;
+}
+
+export interface SessionBranchInfo {
+  sessionId: string;
+  sessionName: string;
+  branchName: string;
+  worktreePath: string;
+  baseCommit: string;
+  baseBranch: string;
+  isStale: boolean;
+  staleSince?: string;
+  hasUncommittedChanges: boolean;
+  pullRequest?: {
+    number: number;
+    title: string;
+    state: 'open' | 'closed' | 'merged';
+    url: string;
+  };
+  commitsAhead: number;
+  commitsBehind: number;
+}
+
+export interface ProjectDashboardData {
+  projectId: number;
+  projectName: string;
+  projectPath: string;
+  mainBranch: string;
+  mainBranchStatus: MainBranchStatus;
+  remotes?: RemoteStatus[];
+  sessionBranches: SessionBranchInfo[];
+  lastRefreshed: string;
+}
+
+export interface ProjectDashboardError {
+  message: string;
+  details?: string;
+}

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -22,6 +22,8 @@ export interface Session {
   autoCommit?: boolean;
   model?: string;
   archived?: boolean;
+  baseCommit?: string;
+  baseBranch?: string;
 }
 
 export interface CreateSessionRequest {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -283,6 +283,14 @@ export class API {
     },
   };
 
+  // Dashboard
+  static dashboard = {
+    async getProjectStatus(projectId: number) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.dashboard.getProjectStatus(projectId);
+    },
+  };
+
   // Folders
   static folders = {
     async getByProject(projectId: number) {

--- a/frontend/src/utils/dashboardCache.ts
+++ b/frontend/src/utils/dashboardCache.ts
@@ -1,0 +1,44 @@
+import type { ProjectDashboardData } from '../types/projectDashboard';
+
+interface CacheEntry {
+  data: ProjectDashboardData;
+  timestamp: number;
+}
+
+class DashboardCache {
+  private cache: Map<number, CacheEntry> = new Map();
+  private readonly CACHE_DURATION = 60 * 1000; // 1 minute cache
+
+  set(projectId: number, data: ProjectDashboardData): void {
+    this.cache.set(projectId, {
+      data,
+      timestamp: Date.now()
+    });
+  }
+
+  get(projectId: number): ProjectDashboardData | null {
+    const entry = this.cache.get(projectId);
+    
+    if (!entry) {
+      return null;
+    }
+    
+    // Check if cache is expired
+    if (Date.now() - entry.timestamp > this.CACHE_DURATION) {
+      this.cache.delete(projectId);
+      return null;
+    }
+    
+    return entry.data;
+  }
+
+  invalidate(projectId: number): void {
+    this.cache.delete(projectId);
+  }
+
+  invalidateAll(): void {
+    this.cache.clear();
+  }
+}
+
+export const dashboardCache = new DashboardCache();

--- a/main/src/database/models.ts
+++ b/main/src/database/models.ts
@@ -58,6 +58,8 @@ export interface Session {
   is_favorite?: boolean;
   auto_commit?: boolean;
   model?: string;
+  base_commit?: string;
+  base_branch?: string;
 }
 
 export interface SessionOutput {
@@ -89,6 +91,8 @@ export interface CreateSessionData {
   display_order?: number;
   auto_commit?: boolean;
   model?: string;
+  base_commit?: string;
+  base_branch?: string;
 }
 
 export interface UpdateSessionData {

--- a/main/src/ipc/dashboard.ts
+++ b/main/src/ipc/dashboard.ts
@@ -1,0 +1,619 @@
+import { IpcMain } from 'electron';
+import { execSync, execAsync } from '../utils/commandExecutor';
+import { formatForDatabase } from '../utils/timestampUtils';
+import type { AppServices } from './types';
+import path from 'path';
+import fs from 'fs';
+
+interface MainBranchStatus {
+  status: 'up-to-date' | 'behind' | 'ahead' | 'diverged';
+  aheadCount?: number;
+  behindCount?: number;
+  lastFetched: string;
+}
+
+interface SessionBranchInfo {
+  sessionId: string;
+  sessionName: string;
+  branchName: string;
+  worktreePath: string;
+  baseCommit: string;
+  baseBranch: string;
+  isStale: boolean;
+  staleSince?: string;
+  hasUncommittedChanges: boolean;
+  pullRequest?: {
+    number: number;
+    title: string;
+    state: 'open' | 'closed' | 'merged';
+    url: string;
+  };
+  commitsAhead: number;
+  commitsBehind: number;
+}
+
+interface RemoteStatus {
+  name: string;
+  url: string;
+  branch: string;
+  status: 'up-to-date' | 'behind' | 'ahead' | 'diverged';
+  aheadCount: number;
+  behindCount: number;
+  isUpstream?: boolean;
+  isFork?: boolean;
+}
+
+interface ProjectDashboardData {
+  projectId: number;
+  projectName: string;
+  projectPath: string;
+  mainBranch: string;
+  mainBranchStatus: MainBranchStatus;
+  remotes?: RemoteStatus[];
+  sessionBranches: SessionBranchInfo[];
+  lastRefreshed: string;
+}
+
+export function registerDashboardHandlers(ipcMain: IpcMain, services: AppServices) {
+  const { databaseService, worktreeManager } = services;
+
+  ipcMain.handle('dashboard:get-project-status', async (_event, projectId: number) => {
+    try {
+      // Get project details
+      const project = databaseService.getProject(projectId);
+      if (!project) {
+        return {
+          success: false,
+          error: 'Project not found'
+        };
+      }
+
+      // Ensure the project path exists and is a git repository
+      if (!fs.existsSync(project.path)) {
+        return {
+          success: false,
+          error: 'Project path does not exist'
+        };
+      }
+
+      const gitDir = path.join(project.path, '.git');
+      if (!fs.existsSync(gitDir)) {
+        return {
+          success: false,
+          error: 'Project is not a git repository'
+        };
+      }
+
+      // Fetch latest changes from remote (async to prevent blocking)
+      try {
+        await execAsync('git fetch origin', { cwd: project.path, timeout: 15000 });
+      } catch (error) {
+        console.warn('Failed to fetch from origin:', error);
+        // Continue anyway - we can still show local status
+      }
+
+      // Get the main branch name dynamically
+      const mainBranch = await worktreeManager.getProjectMainBranch(project.path);
+
+      // Get main branch status (async)
+      const mainBranchStatus = await getMainBranchStatusAsync(project.path, mainBranch);
+      
+      // Get remote statuses (async)
+      const remotes = await getRemoteStatuses(project.path, mainBranch);
+
+      // Get all sessions for this project
+      const sessions = databaseService.getAllSessions(projectId);
+      const sessionBranches: SessionBranchInfo[] = [];
+
+      // Process sessions in batches to prevent overwhelming git
+      const BATCH_SIZE = 5;
+      for (let i = 0; i < sessions.length; i += BATCH_SIZE) {
+        const batch = sessions.slice(i, i + BATCH_SIZE);
+        const batchPromises = batch
+          .filter(session => !session.archived) // Skip archived sessions
+          .map(async (session) => {
+            try {
+              return await getSessionBranchInfoAsync(
+                session,
+                project.path,
+                mainBranch
+              );
+            } catch (error) {
+              console.error(`Failed to get branch info for session ${session.id}:`, error);
+              return null;
+            }
+          });
+
+        const batchResults = await Promise.all(batchPromises);
+        sessionBranches.push(...batchResults.filter(result => result !== null));
+      }
+
+      const dashboardData: ProjectDashboardData = {
+        projectId: project.id,
+        projectName: project.name,
+        projectPath: project.path,
+        mainBranch,
+        mainBranchStatus,
+        remotes: remotes.length > 0 ? remotes : undefined,
+        sessionBranches,
+        lastRefreshed: formatForDatabase()
+      };
+
+      return {
+        success: true,
+        data: dashboardData
+      };
+    } catch (error) {
+      console.error('Error getting project dashboard status:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get project status'
+      };
+    }
+  });
+}
+
+function getMainBranchStatus(projectPath: string, mainBranch: string): MainBranchStatus {
+  try {
+    // Check if we have a remote tracking branch
+    const remoteBranch = `origin/${mainBranch}`;
+    
+    // Check if remote branch exists
+    try {
+      execSync(`git rev-parse --verify ${remoteBranch}`, { cwd: projectPath });
+    } catch {
+      // No remote branch
+      return {
+        status: 'up-to-date',
+        lastFetched: formatForDatabase()
+      };
+    }
+
+    // Get commit counts
+    const aheadBehind = execSync(
+      `git rev-list --left-right --count ${mainBranch}...${remoteBranch}`,
+      { cwd: projectPath }
+    ).toString().trim();
+
+    const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
+
+    let status: MainBranchStatus['status'];
+    if (ahead === 0 && behind === 0) {
+      status = 'up-to-date';
+    } else if (ahead > 0 && behind === 0) {
+      status = 'ahead';
+    } else if (ahead === 0 && behind > 0) {
+      status = 'behind';
+    } else {
+      status = 'diverged';
+    }
+
+    return {
+      status,
+      aheadCount: ahead || undefined,
+      behindCount: behind || undefined,
+      lastFetched: formatForDatabase()
+    };
+  } catch (error) {
+    console.error('Error getting main branch status:', error);
+    return {
+      status: 'up-to-date',
+      lastFetched: formatForDatabase()
+    };
+  }
+}
+
+async function getRemoteStatuses(projectPath: string, mainBranch: string): Promise<RemoteStatus[]> {
+  try {
+    // Get all remotes
+    const remotesResult = await execAsync('git remote -v', { cwd: projectPath, timeout: 5000 });
+    const remoteLines = remotesResult.stdout.trim().split('\n');
+    
+    // Parse unique remotes
+    const remotesMap = new Map<string, string>();
+    for (const line of remoteLines) {
+      const [name, url] = line.split('\t');
+      if (name && url && url.includes('(fetch)')) {
+        remotesMap.set(name, url.replace(' (fetch)', ''));
+      }
+    }
+    
+    const remoteStatuses: RemoteStatus[] = [];
+    
+    // Fetch from all remotes
+    for (const [remoteName, remoteUrl] of remotesMap) {
+      try {
+        await execAsync(`git fetch ${remoteName}`, { cwd: projectPath, timeout: 10000 });
+      } catch (error) {
+        console.warn(`Failed to fetch from ${remoteName}:`, error);
+      }
+      
+      // Check if remote branch exists
+      try {
+        await execAsync(`git rev-parse --verify ${remoteName}/${mainBranch}`, { cwd: projectPath, timeout: 2000 });
+        
+        // Get ahead/behind status
+        const result = await execAsync(
+          `git rev-list --left-right --count ${mainBranch}...${remoteName}/${mainBranch}`,
+          { cwd: projectPath, timeout: 5000 }
+        );
+        const [ahead, behind] = result.stdout.trim().split('\t').map(n => parseInt(n, 10));
+        
+        let status: RemoteStatus['status'];
+        if (ahead === 0 && behind === 0) {
+          status = 'up-to-date';
+        } else if (ahead > 0 && behind === 0) {
+          status = 'ahead';
+        } else if (ahead === 0 && behind > 0) {
+          status = 'behind';
+        } else {
+          status = 'diverged';
+        }
+        
+        // Detect if this is upstream or a fork
+        const isUpstream = remoteName === 'upstream' || remoteUrl.includes('/upstream/');
+        const isFork = !isUpstream && remoteName === 'origin' && remotesMap.has('upstream');
+        
+        remoteStatuses.push({
+          name: remoteName,
+          url: remoteUrl,
+          branch: mainBranch,
+          status,
+          aheadCount: ahead,
+          behindCount: behind,
+          isUpstream,
+          isFork
+        });
+      } catch (error) {
+        // Remote branch doesn't exist
+        console.warn(`Remote branch ${remoteName}/${mainBranch} not found`);
+      }
+    }
+    
+    // Sort remotes: upstream first, then origin, then others
+    remoteStatuses.sort((a, b) => {
+      if (a.isUpstream) return -1;
+      if (b.isUpstream) return 1;
+      if (a.name === 'origin') return -1;
+      if (b.name === 'origin') return 1;
+      return a.name.localeCompare(b.name);
+    });
+    
+    return remoteStatuses;
+  } catch (error) {
+    console.error('Error getting remote statuses:', error);
+    return [];
+  }
+}
+
+async function getMainBranchStatusAsync(projectPath: string, mainBranch: string): Promise<MainBranchStatus> {
+  try {
+    // Check if we have a remote tracking branch
+    const remoteBranch = `origin/${mainBranch}`;
+    
+    // Check if remote branch exists
+    try {
+      await execAsync(`git rev-parse --verify ${remoteBranch}`, { cwd: projectPath, timeout: 5000 });
+    } catch {
+      // No remote branch
+      return {
+        status: 'up-to-date',
+        lastFetched: formatForDatabase()
+      };
+    }
+
+    // Get commit counts
+    const result = await execAsync(
+      `git rev-list --left-right --count ${mainBranch}...${remoteBranch}`,
+      { cwd: projectPath, timeout: 5000 }
+    );
+    const aheadBehind = result.stdout.trim();
+
+    const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
+
+    let status: MainBranchStatus['status'];
+    if (ahead === 0 && behind === 0) {
+      status = 'up-to-date';
+    } else if (ahead > 0 && behind === 0) {
+      status = 'ahead';
+    } else if (ahead === 0 && behind > 0) {
+      status = 'behind';
+    } else {
+      status = 'diverged';
+    }
+
+    return {
+      status,
+      aheadCount: ahead || undefined,
+      behindCount: behind || undefined,
+      lastFetched: formatForDatabase()
+    };
+  } catch (error) {
+    console.error('Error getting main branch status:', error);
+    return {
+      status: 'up-to-date',
+      lastFetched: formatForDatabase()
+    };
+  }
+}
+
+async function getSessionBranchInfo(
+  session: { id: string; name: string; worktree_path: string; base_commit?: string; base_branch?: string },
+  projectPath: string,
+  mainBranch: string
+): Promise<SessionBranchInfo | null> {
+  try {
+    // Check if worktree still exists
+    if (!fs.existsSync(session.worktree_path)) {
+      return null;
+    }
+
+    // Get the branch name from the worktree
+    const branchName = execSync('git branch --show-current', { 
+      cwd: session.worktree_path 
+    }).toString().trim();
+
+    if (!branchName) {
+      return null;
+    }
+
+    // Get the base commit this branch was created from
+    // This is stored in the session metadata or we can infer it
+    let baseCommit = session.base_commit;
+    const baseBranch = session.base_branch || mainBranch;
+
+    if (!baseCommit) {
+      // Try to find the merge-base with main
+      try {
+        baseCommit = execSync(
+          `git merge-base ${branchName} ${mainBranch}`,
+          { cwd: session.worktree_path }
+        ).toString().trim();
+      } catch {
+        baseCommit = 'unknown';
+      }
+    }
+
+    // Check if base branch has moved (session is stale)
+    let isStale = false;
+    let staleSince: string | undefined;
+    
+    if (baseCommit && baseCommit !== 'unknown') {
+      try {
+        const currentBaseCommit = execSync(
+          `git rev-parse ${baseBranch}`,
+          { cwd: projectPath }
+        ).toString().trim();
+        
+        isStale = currentBaseCommit !== baseCommit;
+        
+        if (isStale) {
+          // Try to get the timestamp when the base branch moved
+          const commitDate = execSync(
+            `git log -1 --format=%cd --date=iso-strict ${currentBaseCommit}`,
+            { cwd: projectPath }
+          ).toString().trim();
+          staleSince = commitDate;
+        }
+      } catch {
+        // Ignore errors
+      }
+    }
+
+    // Check for uncommitted changes
+    const hasUncommittedChanges = checkUncommittedChanges(session.worktree_path);
+
+    // Get commits ahead/behind
+    let commitsAhead = 0;
+    let commitsBehind = 0;
+    
+    try {
+      const aheadBehind = execSync(
+        `git rev-list --left-right --count ${branchName}...${baseBranch}`,
+        { cwd: session.worktree_path }
+      ).toString().trim();
+      
+      const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
+      commitsAhead = ahead;
+      commitsBehind = behind;
+    } catch {
+      // Ignore errors
+    }
+
+    // Check for associated pull request
+    let pullRequest: SessionBranchInfo['pullRequest'];
+    try {
+      const prOutput = execSync(
+        `gh pr list --head ${branchName} --json number,title,state,url --limit 1`,
+        { cwd: projectPath }
+      ).toString().trim();
+      
+      if (prOutput) {
+        const prs = JSON.parse(prOutput);
+        if (prs.length > 0) {
+          const pr = prs[0];
+          pullRequest = {
+            number: pr.number,
+            title: pr.title,
+            state: pr.state.toLowerCase() as 'open' | 'closed' | 'merged',
+            url: pr.url
+          };
+        }
+      }
+    } catch {
+      // gh command might not be available or configured
+    }
+
+    return {
+      sessionId: session.id,
+      sessionName: session.name,
+      branchName,
+      worktreePath: session.worktree_path,
+      baseCommit,
+      baseBranch,
+      isStale,
+      staleSince,
+      hasUncommittedChanges,
+      pullRequest,
+      commitsAhead,
+      commitsBehind
+    };
+  } catch (error) {
+    console.error(`Error getting branch info for session ${session.id}:`, error);
+    return null;
+  }
+}
+
+async function getSessionBranchInfoAsync(
+  session: { id: string; name: string; worktree_path: string; base_commit?: string; base_branch?: string },
+  projectPath: string,
+  mainBranch: string
+): Promise<SessionBranchInfo | null> {
+  try {
+    // Check if worktree still exists
+    if (!fs.existsSync(session.worktree_path)) {
+      return null;
+    }
+
+    // Get the branch name from the worktree
+    const branchResult = await execAsync('git branch --show-current', { 
+      cwd: session.worktree_path,
+      timeout: 5000
+    });
+    const branchName = branchResult.stdout.trim();
+
+    if (!branchName) {
+      return null;
+    }
+
+    // Get the base commit this branch was created from
+    // This is stored in the session metadata or we can infer it
+    let baseCommit = session.base_commit;
+    const baseBranch = session.base_branch || mainBranch;
+
+    if (!baseCommit) {
+      // Try to find the merge-base with main
+      try {
+        const mergeBaseResult = await execAsync(
+          `git merge-base ${branchName} ${mainBranch}`,
+          { cwd: session.worktree_path, timeout: 5000 }
+        );
+        baseCommit = mergeBaseResult.stdout.trim();
+      } catch {
+        baseCommit = 'unknown';
+      }
+    }
+
+    // Check if base branch has moved (session is stale)
+    let isStale = false;
+    let staleSince: string | undefined;
+    
+    if (baseCommit && baseCommit !== 'unknown') {
+      try {
+        const currentBaseResult = await execAsync(
+          `git rev-parse ${baseBranch}`,
+          { cwd: projectPath, timeout: 5000 }
+        );
+        const currentBaseCommit = currentBaseResult.stdout.trim();
+        
+        isStale = currentBaseCommit !== baseCommit;
+        
+        if (isStale) {
+          // Try to get the timestamp when the base branch moved
+          const commitDateResult = await execAsync(
+            `git log -1 --format=%cd --date=iso-strict ${currentBaseCommit}`,
+            { cwd: projectPath, timeout: 5000 }
+          );
+          staleSince = commitDateResult.stdout.trim();
+        }
+      } catch {
+        // Ignore errors
+      }
+    }
+
+    // Check for uncommitted changes (async)
+    const hasUncommittedChanges = await checkUncommittedChangesAsync(session.worktree_path);
+
+    // Get commits ahead/behind
+    let commitsAhead = 0;
+    let commitsBehind = 0;
+    
+    try {
+      const aheadBehindResult = await execAsync(
+        `git rev-list --left-right --count ${branchName}...${baseBranch}`,
+        { cwd: session.worktree_path, timeout: 5000 }
+      );
+      const aheadBehind = aheadBehindResult.stdout.trim();
+      
+      const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
+      commitsAhead = ahead;
+      commitsBehind = behind;
+    } catch {
+      // Ignore errors
+    }
+
+    // Check for associated pull request (async)
+    let pullRequest: SessionBranchInfo['pullRequest'];
+    try {
+      const prResult = await execAsync(
+        `gh pr list --head ${branchName} --json number,title,state,url --limit 1`,
+        { cwd: projectPath, timeout: 10000 }
+      );
+      const prOutput = prResult.stdout.trim();
+      
+      if (prOutput) {
+        const prs = JSON.parse(prOutput);
+        if (prs.length > 0) {
+          const pr = prs[0];
+          pullRequest = {
+            number: pr.number,
+            title: pr.title,
+            state: pr.state.toLowerCase() as 'open' | 'closed' | 'merged',
+            url: pr.url
+          };
+        }
+      }
+    } catch {
+      // gh command might not be available or configured
+    }
+
+    return {
+      sessionId: session.id,
+      sessionName: session.name,
+      branchName,
+      worktreePath: session.worktree_path,
+      baseCommit,
+      baseBranch,
+      isStale,
+      staleSince,
+      hasUncommittedChanges,
+      pullRequest,
+      commitsAhead,
+      commitsBehind
+    };
+  } catch (error) {
+    console.error(`Error getting branch info for session ${session.id}:`, error);
+    return null;
+  }
+}
+
+function checkUncommittedChanges(worktreePath: string): boolean {
+  try {
+    const status = execSync('git status --porcelain', { cwd: worktreePath }).toString();
+    return status.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function checkUncommittedChangesAsync(worktreePath: string): Promise<boolean> {
+  try {
+    const result = await execAsync('git status --porcelain', { 
+      cwd: worktreePath, 
+      timeout: 5000 
+    });
+    return result.stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -13,6 +13,7 @@ import { registerStravuHandlers } from './stravu';
 import { registerFileHandlers } from './file';
 import { registerFolderHandlers } from './folders';
 import { registerUIStateHandlers } from './uiState';
+import { registerDashboardHandlers } from './dashboard';
 
 
 export function registerIpcHandlers(services: AppServices): void {
@@ -29,4 +30,5 @@ export function registerIpcHandlers(services: AppServices): void {
   registerFileHandlers(ipcMain, services);
   registerFolderHandlers(ipcMain, services);
   registerUIStateHandlers(services);
+  registerDashboardHandlers(ipcMain, services);
 } 

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -113,6 +113,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     listBranches: (projectId: string): Promise<IPCResponse> => ipcRenderer.invoke('projects:list-branches', projectId),
   },
 
+  // Project Dashboard
+  dashboard: {
+    getProjectStatus: (projectId: number): Promise<IPCResponse> => ipcRenderer.invoke('dashboard:get-project-status', projectId),
+  },
+
   // Git operations
   git: {
     detectBranch: (path: string): Promise<IPCResponse<string>> => ipcRenderer.invoke('projects:detect-branch', path),

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -113,7 +113,9 @@ export class SessionManager extends EventEmitter {
       isFavorite: dbSession.is_favorite,
       autoCommit: dbSession.auto_commit,
       model: dbSession.model,
-      archived: dbSession.archived || false
+      archived: dbSession.archived || false,
+      baseCommit: dbSession.base_commit,
+      baseBranch: dbSession.base_branch
     };
   }
 
@@ -163,11 +165,11 @@ export class SessionManager extends EventEmitter {
     return dbSession ? this.convertDbSessionToSession(dbSession) : undefined;
   }
 
-  createSession(name: string, worktreePath: string, prompt: string, worktreeName: string, permissionMode?: 'approve' | 'ignore', projectId?: number, isMainRepo?: boolean, autoCommit?: boolean, folderId?: string, model?: string): Session {
-    return this.createSessionWithId(randomUUID(), name, worktreePath, prompt, worktreeName, permissionMode, projectId, isMainRepo, autoCommit, folderId, model);
+  createSession(name: string, worktreePath: string, prompt: string, worktreeName: string, permissionMode?: 'approve' | 'ignore', projectId?: number, isMainRepo?: boolean, autoCommit?: boolean, folderId?: string, model?: string, baseCommit?: string, baseBranch?: string): Session {
+    return this.createSessionWithId(randomUUID(), name, worktreePath, prompt, worktreeName, permissionMode, projectId, isMainRepo, autoCommit, folderId, model, baseCommit, baseBranch);
   }
 
-  createSessionWithId(id: string, name: string, worktreePath: string, prompt: string, worktreeName: string, permissionMode?: 'approve' | 'ignore', projectId?: number, isMainRepo?: boolean, autoCommit?: boolean, folderId?: string, model?: string): Session {
+  createSessionWithId(id: string, name: string, worktreePath: string, prompt: string, worktreeName: string, permissionMode?: 'approve' | 'ignore', projectId?: number, isMainRepo?: boolean, autoCommit?: boolean, folderId?: string, model?: string, baseCommit?: string, baseBranch?: string): Session {
     console.log(`[SessionManager] Creating session with ID ${id}: ${name}`);
     
     let targetProject;
@@ -198,7 +200,9 @@ export class SessionManager extends EventEmitter {
       permission_mode: permissionMode,
       is_main_repo: isMainRepo,
       auto_commit: autoCommit,
-      model: model
+      model: model,
+      base_commit: baseCommit,
+      base_branch: baseBranch
     };
     console.log(`[SessionManager] Session data:`, sessionData);
 

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -173,8 +173,9 @@ export class TaskQueue {
           run_script: targetProject.run_script
         }, null, 2));
 
-        const { worktreePath } = await worktreeManager.createWorktree(targetProject.path, worktreeName, undefined, baseBranch, targetProject.worktree_folder);
+        const { worktreePath, baseCommit, baseBranch: actualBaseBranch } = await worktreeManager.createWorktree(targetProject.path, worktreeName, undefined, baseBranch, targetProject.worktree_folder);
         console.log(`[TaskQueue] Worktree created at: ${worktreePath}`);
+        console.log(`[TaskQueue] Base commit: ${baseCommit}, Base branch: ${actualBaseBranch}`);
         
         const sessionName = worktreeName;
         console.log(`[TaskQueue] Creating session in database`);
@@ -189,7 +190,9 @@ export class TaskQueue {
           false, // isMainRepo = false for regular sessions
           autoCommit,
           job.data.folderId,
-          model
+          model,
+          baseCommit,
+          actualBaseBranch
         );
         console.log(`[TaskQueue] Session created with ID: ${session.id}`);
 

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -22,6 +22,8 @@ export interface Session {
   autoCommit?: boolean;
   model?: string;
   archived?: boolean;
+  baseCommit?: string;
+  baseBranch?: string;
 }
 
 export interface CreateSessionRequest {

--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -1,5 +1,8 @@
-import { execSync as nodeExecSync, ExecSyncOptions, ExecSyncOptionsWithStringEncoding, ExecSyncOptionsWithBufferEncoding } from 'child_process';
+import { execSync as nodeExecSync, ExecSyncOptions, ExecSyncOptionsWithStringEncoding, ExecSyncOptionsWithBufferEncoding, exec, ExecOptions } from 'child_process';
+import { promisify } from 'util';
 import { getShellPath } from './shellPath';
+
+const nodeExecAsync = promisify(exec);
 
 class CommandExecutor {
   execSync(command: string, options: ExecSyncOptionsWithStringEncoding): string;
@@ -43,6 +46,49 @@ class CommandExecutor {
       throw error;
     }
   }
+
+  async execAsync(command: string, options?: ExecOptions & { timeout?: number }): Promise<{ stdout: string; stderr: string }> {
+    // Log the command being executed
+    const cwd = options?.cwd || process.cwd();
+    console.log(`[CommandExecutor] Executing async: ${command} in ${cwd}`);
+
+    // Get enhanced shell PATH
+    const shellPath = getShellPath();
+    
+    // Set up timeout (default 10 seconds)
+    const timeout = options?.timeout || 10000;
+    
+    // Merge enhanced PATH into options
+    const enhancedOptions: ExecOptions = {
+      ...options,
+      timeout,
+      env: {
+        ...process.env,
+        ...options?.env,
+        PATH: shellPath
+      }
+    };
+
+    try {
+      const result = await nodeExecAsync(command, enhancedOptions);
+      
+      // Log success with a preview of the result
+      if (result.stdout) {
+        const lines = result.stdout.split('\n');
+        const preview = lines[0].substring(0, 100) + 
+                        (lines.length > 1 ? ` ... (${lines.length} lines)` : '');
+        console.log(`[CommandExecutor] Async Success: ${preview}`);
+      }
+      
+      return result;
+    } catch (error: any) {
+      // Log error
+      console.error(`[CommandExecutor] Async Failed: ${command}`);
+      console.error(`[CommandExecutor] Async Error: ${error.message}`);
+      
+      throw error;
+    }
+  }
 }
 
 // Export a singleton instance
@@ -50,3 +96,6 @@ export const commandExecutor = new CommandExecutor();
 
 // Export the execSync function as a drop-in replacement
 export const execSync = commandExecutor.execSync.bind(commandExecutor);
+
+// Export the execAsync function
+export const execAsync = commandExecutor.execAsync.bind(commandExecutor);


### PR DESCRIPTION
## Summary

This PR introduces a new **Project Dashboard** view that fundamentally changes how users interact with projects in Crystal. Instead of showing a dialog to create sessions without worktrees, clicking on a project now displays a comprehensive dashboard with git status information.

## Key Changes

### 🎯 Replaces Non-Worktree Session Creation Dialog
- **Before**: Clicking a project showed a dialog asking if you want to create a session without a worktree
- **After**: Clicking a project displays a full dashboard with project status and existing sessions

### 📊 New Project Dashboard Features

#### Multi-Origin Git Status Display
- Visual cascade showing the flow: `upstream → origin/fork → local main → session branches`
- Automatically detects and displays multiple remotes
- Color-coded status indicators:
  - 🟢 Green = Synced
  - 🟡 Yellow = Behind
  - 🔵 Blue = Ahead  
  - 🔴 Red = Diverged
- Shows commit counts for ahead/behind status
- "Fork" badge when origin is a fork with an upstream

#### Session Management
- Comprehensive table showing all session branches
- Quick filtering options:
  - All Sessions
  - Stale Only
  - With Changes
  - With PR
- Click any session row to navigate directly to that session
- Full viewport scrolling for projects with many sessions

#### Status Summary Cards
- **Up to date**: Shows how many sessions are current (e.g., "8/12")
- **Stale**: Count of sessions behind their base branch
- **Changes**: Sessions with uncommitted changes

### 🐛 Fixes Included
- Project name now displays correctly in dashboard header
- Sessions table properly scrolls when there are many sessions
- Sidebar session clicking now correctly navigates to sessions
- Proper skeleton loading states when switching between projects

### 🏗️ Technical Implementation
- New IPC endpoint: `dashboard:get-project-status`
- Caching layer for dashboard data to improve performance
- Fetches from all git remotes to show complete status
- New navigation store to manage dashboard vs session views
- Responsive design with proper viewport utilization

## Screenshots

The dashboard provides immediate visibility into:
1. Is my fork behind the upstream?
2. Is my local main behind my fork's origin?
3. Which sessions are stale and need updating?

All this information is now available at a glance without needing to create a new session.

## Testing
- Click on any project in the sidebar to see the new dashboard
- Test with projects that have:
  - Single remote (origin only)
  - Multiple remotes (upstream + origin)
  - Many sessions to verify scrolling
- Use the filter dropdown to filter sessions
- Click on sessions to verify navigation works

This change significantly improves the UX by providing immediate project insights and making session management more intuitive.