### PR TITLE
Remove redundant 'Working Directory' from About dialog

### DIFF
--- a/frontend/src/components/AboutDialog.tsx
+++ b/frontend/src/components/AboutDialog.tsx
@@ -168,17 +168,6 @@ export function AboutDialog({ isOpen, onClose }: AboutDialogProps) {
               </span>
             </div>
 
-            {versionInfo?.workingDirectory && (
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Working Directory
-                </span>
-                <span className="text-sm text-gray-900 dark:text-white font-mono truncate max-w-[200px]" title={versionInfo.workingDirectory}>
-                  {versionInfo.workingDirectory.split('/').pop() || versionInfo.workingDirectory}
-                </span>
-              </div>
-            )}
-
             {versionInfo?.worktreeName && (
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
The worktree branch name already provides the necessary information, making the working directory display redundant.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist
<!-- Please check all that apply -->
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
<!-- Check if you modified any of these critical areas -->
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->