### PR TITLE
Add Windows compatibility and fix notification settings synchronization

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -15,6 +15,7 @@ The following packages are licensed under the MIT license:
   - @antfu/install-pkg (1.1.0) - Anthony Fu <anthonyfu117@hotmail.com>
   - @antfu/utils (8.1.1) - Anthony Fu <anthonyfu117@hotmail.com>
   - @anthropic-ai/sdk (0.53.0) - Anthropic <support@anthropic.com>
+  - @anthropic-ai/sdk (0.57.0) - Anthropic <support@anthropic.com>
   - @babel/code-frame (7.27.1) - The Babel Team (https://babel.dev/team)
   - @babel/compat-data (7.28.0) - The Babel Team (https://babel.dev/team)
   - @babel/core (7.28.0) - The Babel Team (https://babel.dev/team)
@@ -27,17 +28,26 @@ The following packages are licensed under the MIT license:
   - @babel/helper-validator-identifier (7.27.1) - The Babel Team (https://babel.dev/team)
   - @babel/helper-validator-option (7.27.1) - The Babel Team (https://babel.dev/team)
   - @babel/helpers (7.27.6) - The Babel Team (https://babel.dev/team)
+  - @babel/helpers (7.28.2) - The Babel Team (https://babel.dev/team)
   - @babel/parser (7.28.0) - The Babel Team (https://babel.dev/team)
   - @babel/runtime (7.27.6) - The Babel Team (https://babel.dev/team)
+  - @babel/runtime (7.28.2) - The Babel Team (https://babel.dev/team)
   - @babel/template (7.27.2) - The Babel Team (https://babel.dev/team)
   - @babel/traverse (7.28.0) - The Babel Team (https://babel.dev/team)
   - @babel/types (7.28.1) - The Babel Team (https://babel.dev/team)
+  - @babel/types (7.28.2) - The Babel Team (https://babel.dev/team)
+  - @bcoe/v8-coverage (0.2.3) - Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)
   - @braintree/sanitize-url (7.1.1)
   - @develar/schema-utils (2.6.5) - webpack Contrib (https://github.com/webpack-contrib)
+  - @electron/asar (3.2.18)
   - @electron/asar (3.4.1)
+  - @electron/fuses (1.8.0) - Electron Community
   - @electron/get (2.0.3) - Samuel Attard
+  - @electron/node-gyp (10.2.0-electron.1) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - @electron/notarize (2.5.0) - Samuel Attard
   - @electron/rebuild (3.6.1) - Paul Betts <paul@paulbetts.org>
+  - @electron/rebuild (3.7.0)
+  - @electron/rebuild (4.0.1)
   - @electron/universal (2.0.1) - Samuel Attard
   - @emotion/babel-plugin (11.13.5) - Kye Hohenberger
   - @emotion/cache (11.14.0)
@@ -49,16 +59,71 @@ The following packages are licensed under the MIT license:
   - @emotion/unitless (0.10.0)
   - @emotion/utils (1.4.2)
   - @emotion/weak-memoize (0.4.0)
+<<<<<<< HEAD
   - @esbuild/darwin-arm64 (0.25.7)
+=======
+  - @esbuild/aix-ppc64 (0.21.5)
+  - @esbuild/aix-ppc64 (0.25.8)
+  - @esbuild/android-arm (0.21.5)
+  - @esbuild/android-arm (0.25.8)
+  - @esbuild/android-arm64 (0.21.5)
+  - @esbuild/android-arm64 (0.25.8)
+  - @esbuild/android-x64 (0.21.5)
+  - @esbuild/android-x64 (0.25.8)
+  - @esbuild/darwin-arm64 (0.21.5)
+  - @esbuild/darwin-arm64 (0.25.8)
+  - @esbuild/darwin-x64 (0.21.5)
+  - @esbuild/darwin-x64 (0.25.8)
+  - @esbuild/freebsd-arm64 (0.21.5)
+  - @esbuild/freebsd-arm64 (0.25.8)
+  - @esbuild/freebsd-x64 (0.21.5)
+  - @esbuild/freebsd-x64 (0.25.8)
+  - @esbuild/linux-arm (0.21.5)
+  - @esbuild/linux-arm (0.25.8)
+  - @esbuild/linux-arm64 (0.21.5)
+  - @esbuild/linux-arm64 (0.25.8)
+  - @esbuild/linux-ia32 (0.21.5)
+  - @esbuild/linux-ia32 (0.25.8)
+  - @esbuild/linux-loong64 (0.21.5)
+  - @esbuild/linux-loong64 (0.25.8)
+  - @esbuild/linux-mips64el (0.21.5)
+  - @esbuild/linux-mips64el (0.25.8)
+  - @esbuild/linux-ppc64 (0.21.5)
+  - @esbuild/linux-ppc64 (0.25.8)
+  - @esbuild/linux-riscv64 (0.21.5)
+  - @esbuild/linux-riscv64 (0.25.8)
+  - @esbuild/linux-s390x (0.21.5)
+  - @esbuild/linux-s390x (0.25.8)
+  - @esbuild/linux-x64 (0.21.5)
+  - @esbuild/linux-x64 (0.25.8)
+  - @esbuild/netbsd-arm64 (0.25.8)
+  - @esbuild/netbsd-x64 (0.21.5)
+  - @esbuild/netbsd-x64 (0.25.8)
+  - @esbuild/openbsd-arm64 (0.25.8)
+  - @esbuild/openbsd-x64 (0.21.5)
+  - @esbuild/openbsd-x64 (0.25.8)
+  - @esbuild/openharmony-arm64 (0.25.8)
+  - @esbuild/sunos-x64 (0.21.5)
+  - @esbuild/sunos-x64 (0.25.8)
+  - @esbuild/win32-arm64 (0.21.5)
+  - @esbuild/win32-arm64 (0.25.8)
+  - @esbuild/win32-ia32 (0.21.5)
+  - @esbuild/win32-ia32 (0.25.8)
+  - @esbuild/win32-x64 (0.21.5)
+  - @esbuild/win32-x64 (0.25.7)
+  - @esbuild/win32-x64 (0.25.8)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - @eslint-community/regexpp (4.12.1) - Toru Nagashima
   - @floating-ui/core (1.7.2) - atomiks
   - @floating-ui/dom (1.7.2) - atomiks
   - @floating-ui/utils (0.2.10) - atomiks
   - @gar/promisify (1.1.3) - Gar <gar+npm@danger.computer>
   - @homebridge/node-pty-prebuilt-multiarch (0.12.0) - Microsoft Corporation
+  - @homebridge/node-pty-prebuilt-multiarch (0.13.1) - Microsoft Corporation
   - @iconify/types (2.0.0) - Vjacheslav Trushkin
   - @iconify/utils (2.3.0) - Vjacheslav Trushkin
   - @ioredis/commands (1.2.0) - Zihua Li <i@zihua.li> (http://zihua.li)
+  - @ioredis/commands (1.3.0) - Zihua Li <i@zihua.li> (http://zihua.li)
   - @isaacs/balanced-match (4.0.1)
   - @isaacs/brace-expansion (5.0.0)
   - @jridgewell/gen-mapping (0.3.12) - Justin Ridgewell <justin@ridgewell.name>
@@ -68,8 +133,19 @@ The following packages are licensed under the MIT license:
   - @malept/flatpak-bundler (0.4.0) - Matt Watson <mattdangerw@gmail.com>
   - @mermaid-js/parser (0.6.2) - Yokozuna59
   - @modelcontextprotocol/sdk (1.16.0) - Anthropic, PBC (https://anthropic.com)
+  - @modelcontextprotocol/sdk (1.17.0) - Anthropic, PBC (https://anthropic.com)
   - @monaco-editor/loader (1.5.0) - Suren Atoyan <contact@surenatoyan.com>
+<<<<<<< HEAD
   - @msgpackr-extract/msgpackr-extract-darwin-arm64 (3.0.3) - Kris Zyp
+=======
+  - @monaco-editor/react (4.7.0) - Suren Atoyan <contact@surenatoyan.com>
+  - @msgpackr-extract/msgpackr-extract-darwin-arm64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-darwin-x64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-linux-arm (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-linux-arm64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-linux-x64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-win32-x64 (3.0.3) - Kris Zyp
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - @nodelib/fs.scandir (2.1.5)
   - @nodelib/fs.stat (2.0.5)
   - @nodelib/fs.walk (1.2.8)
@@ -79,13 +155,38 @@ The following packages are licensed under the MIT license:
   - @radix-ui/primitive (1.1.2)
   - @radix-ui/rect (1.1.1)
   - @rolldown/pluginutils (1.0.0-beta.27)
+<<<<<<< HEAD
   - @rollup/rollup-darwin-arm64 (4.45.1) - Lukas Taegert-Atkinson
+=======
+  - @rollup/rollup-android-arm-eabi (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-android-arm64 (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-darwin-arm64 (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-darwin-x64 (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-freebsd-arm64 (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-freebsd-x64 (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-arm-gnueabihf (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-arm-musleabihf (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-arm64-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-arm64-musl (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-loongarch64-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-ppc64-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-riscv64-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-riscv64-musl (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-s390x-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-x64-gnu (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-x64-musl (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-arm64-msvc (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-ia32-msvc (4.46.0) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-x64-msvc (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-x64-msvc (4.46.0) - Lukas Taegert-Atkinson
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - @sindresorhus/is (4.6.0) - Sindre Sorhus
   - @szmarczak/http-timer (4.0.6) - Szymon Marczak
   - @tootallnate/once (2.0.0) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - @xmldom/xmldom (0.8.10)
   - @xterm/xterm (5.5.0)
   - 7zip-bin (5.2.0)
+  - abort-controller (3.0.0) - Toru Nagashima (https://github.com/mysticatea)
   - accepts (2.0.0)
   - acorn (8.15.0)
   - acorn-jsx (5.3.2)
@@ -103,23 +204,34 @@ The following packages are licensed under the MIT license:
   - ansi-styles (6.2.1) - Sindre Sorhus
   - any-promise (1.3.0) - Kevin Beaty
   - app-builder-bin (5.0.0-alpha.10)
+  - app-builder-bin (5.0.0-alpha.12)
   - app-builder-lib (25.1.8) - Vladimir Krivosheev
+<<<<<<< HEAD
   - archiver (5.3.2) - Chris Talkington
   - archiver-utils (2.1.0) - Chris Talkington
   - archiver-utils (3.0.4) - Chris Talkington
   - arg (5.0.2) - Josh Junon <junon@wavetilt.com>
   - aria-hidden (1.2.6) - Anton Korzunov <thekashey@gmail.com>
   - assert-plus (1.0.0) - Mark Cavage <mcavage@gmail.com>
+=======
+  - app-builder-lib (26.0.12) - Vladimir Krivosheev
+  - arg (5.0.2) - Josh Junon <junon@wavetilt.com>
+  - aria-hidden (1.2.6) - Anton Korzunov <thekashey@gmail.com>
+  - assert-plus (1.0.0) - Mark Cavage <mcavage@gmail.com>
+  - assertion-error (2.0.1) - Jake Luer <jake@qualiancy.com> (http://qualiancy.com)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - astral-regex (2.0.0) - Kevin Mårtensson
   - async (3.2.6) - Caolan McMahon
   - async-exit-hook (2.0.1) - Tapani Moilanen
   - asynckit (0.4.0) - Alex Indigo <iam@alexindigo.com>
   - axios (1.10.0) - Matt Zabriskie
+  - axios (1.11.0) - Matt Zabriskie
   - babel-plugin-macros (3.1.0) - Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)
   - bail (2.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - balanced-match (1.0.2) - Julian Gruber
   - base64-js (1.5.1) - T. Jameson Little <t.jameson.little@gmail.com>
   - better-sqlite3 (11.10.0) - Joshua Wise <joshuathomaswise@gmail.com>
+  - better-sqlite3 (12.2.0) - Joshua Wise <joshuathomaswise@gmail.com>
   - binary-extensions (2.3.0) - Sindre Sorhus
   - bindings (1.5.0) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - bl (4.1.0)
@@ -135,6 +247,7 @@ The following packages are licensed under the MIT license:
   - buffer-crc32 (0.2.13) - Brian J. Brennan <brianloveswords@gmail.com>
   - buffer-from (1.1.2)
   - builder-util (25.1.7) - Vladimir Krivosheev
+  - builder-util (26.0.11) - Vladimir Krivosheev
   - builder-util-runtime (9.2.10) - Vladimir Krivosheev
   - builder-util-runtime (9.3.1) - Vladimir Krivosheev
   - bull (4.16.5) - OptimalBits
@@ -171,8 +284,8 @@ The following packages are licensed under the MIT license:
   - commander (5.1.0) - TJ Holowaychuk <tj@vision-media.ca>
   - commander (7.2.0) - TJ Holowaychuk <tj@vision-media.ca>
   - commander (8.3.0) - TJ Holowaychuk <tj@vision-media.ca>
+  - commander (9.5.0) - TJ Holowaychuk <tj@vision-media.ca>
   - compare-version (0.1.2) - Kevin Mårtensson
-  - compress-commons (4.1.2) - Chris Talkington
   - concat-map (0.0.1) - James Halliday
   - conf (14.0.0) - Sindre Sorhus
   - confbox (0.1.8)
@@ -184,6 +297,7 @@ The following packages are licensed under the MIT license:
   - convert-source-map (2.0.0) - Thorsten Lorenz
   - cookie (0.7.2) - Roman Shtylman <shtylman@gmail.com>
   - cookie-signature (1.2.2) - TJ Holowaychuk <tj@learnboost.com>
+  - copyfiles (2.4.1)
   - core-util-is (1.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - core-util-is (1.0.3) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - cors (2.8.5) - Troy Goode <troygoode@gmail.com> (https://github.com/troygoode/)
@@ -191,8 +305,12 @@ The following packages are licensed under the MIT license:
   - cose-base (2.2.0)
   - cosmiconfig (7.1.0) - David Clark <david.dave.clark@gmail.com>
   - crc (3.8.0) - Alex Gorbatchev
+<<<<<<< HEAD
   - crc32-stream (4.0.3) - Chris Talkington
+=======
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - cron-parser (4.9.0) - Harri Siirak
+  - cross-dirname (0.1.0)
   - cross-spawn (7.0.6) - André Cruz <andre@moxy.studio>
   - cssesc (3.0.0) - Mathias Bynens
   - csstype (3.1.3) - Fredrik Nicol <fredrik.nicol@gmail.com>
@@ -222,15 +340,23 @@ The following packages are licensed under the MIT license:
   - dir-compare (4.2.0) - Liviu Grigorescu
   - dlv (1.1.3) - Jason Miller <jason@developit.ca> (http://jasonformat.com)
   - dmg-builder (25.1.8) - Vladimir Krivosheev
+<<<<<<< HEAD
+=======
+  - dmg-builder (26.0.12) - Vladimir Krivosheev
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - dmg-license (1.0.11) - argvminusone
   - dot-prop (9.0.0) - Sindre Sorhus
   - dunder-proto (1.0.1) - Jordan Harband <ljharb@gmail.com>
   - eastasianwidth (0.2.0) - Masaki Komagata
   - ee-first (1.1.1) - Jonathan Ong
   - electron (36.7.1) - Electron Community
+  - electron (36.7.3) - Electron Community
+  - electron (37.2.4) - Electron Community
   - electron-publish (25.1.7) - Vladimir Krivosheev
+  - electron-publish (26.0.11) - Vladimir Krivosheev
   - electron-store (10.1.0) - Sindre Sorhus
   - electron-updater (6.6.2) - Vladimir Krivosheev
+  - electron-winstaller (5.4.0)
   - emoji-regex (8.0.0) - Mathias Bynens
   - emoji-regex (9.2.2) - Mathias Bynens
   - encodeurl (2.0.0)
@@ -246,12 +372,14 @@ The following packages are licensed under the MIT license:
   - es-set-tostringtag (2.1.0) - Jordan Harband <ljharb@gmail.com>
   - es6-error (4.1.1) - Ben Youngblood
   - esbuild (0.25.7)
+  - esbuild (0.25.8)
   - escalade (3.2.0) - Luke Edwards
   - escape-html (1.0.3)
   - escape-string-regexp (4.0.0) - Sindre Sorhus
   - escape-string-regexp (5.0.0) - Sindre Sorhus
   - estree-util-is-identifier-name (3.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - etag (1.8.1)
+  - event-target-shim (5.0.1) - Toru Nagashima
   - eventsource (3.0.7) - Espen Hovlandsdal <espen@hovlandsdal.com>
   - eventsource-parser (3.0.3) - Espen Hovlandsdal <espen@hovlandsdal.com>
   - express (5.1.0) - TJ Holowaychuk <tj@vision-media.ca>
@@ -274,12 +402,18 @@ The following packages are licensed under the MIT license:
   - flat-cache (4.0.1) - Jared Wray
   - follow-redirects (1.15.9) - Ruben Verborgh <ruben@verborgh.org> (https://ruben.verborgh.org/)
   - form-data (4.0.4) - Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)
+  - form-data-encoder (1.7.2) - Nick K.
+  - formdata-node (4.4.1) - Nick K. <io@octetstream.me>
   - forwarded (0.2.0)
   - fraction.js (4.3.7) - Robert Eisele
   - fresh (2.0.0) - TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)
   - fs-constants (1.0.0) - Mathias Buus (@mafintosh)
   - fs-extra (10.1.0) - JP Richardson <jprichardson@gmail.com>
   - fs-extra (11.3.0) - JP Richardson <jprichardson@gmail.com>
+<<<<<<< HEAD
+=======
+  - fs-extra (7.0.1) - JP Richardson <jprichardson@gmail.com>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - fs-extra (8.1.0) - JP Richardson <jprichardson@gmail.com>
   - fs-extra (9.1.0) - JP Richardson <jprichardson@gmail.com>
   - fsevents (2.3.2)
@@ -320,6 +454,7 @@ The following packages are licensed under the MIT license:
   - imurmurhash (0.1.4) - Jens Taylor
   - indent-string (4.0.0) - Sindre Sorhus
   - inline-style-parser (0.2.4)
+  - interpret (1.4.0) - Gulp Team <team@gulpjs.com> (http://gulpjs.com/)
   - ioredis (5.6.1) - Zihua Li <i@zihua.li> (http://zihua.li)
   - ip-address (9.0.5) - Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)
   - ipaddr.js (1.9.1) - whitequark <whitequark@whitequark.org>
@@ -340,6 +475,7 @@ The following packages are licensed under the MIT license:
   - is-plain-obj (4.1.0) - Sindre Sorhus
   - is-promise (4.0.0) - ForbesLindesay
   - is-unicode-supported (0.1.0) - Sindre Sorhus
+  - isarray (0.0.1) - Julian Gruber
   - isarray (1.0.0) - Julian Gruber
   - isbinaryfile (4.0.10)
   - isbinaryfile (5.0.4)
@@ -363,7 +499,6 @@ The following packages are licensed under the MIT license:
   - layout-base (1.0.2)
   - layout-base (2.0.1)
   - lazy-val (1.0.5) - Vladimir Krivosheev
-  - lazystream (1.0.1) - Jonas Pommerening
   - levn (0.4.1) - George Zahariev <z@georgezahariev.com>
   - lilconfig (3.1.3) - antonk52
   - lines-and-columns (1.2.4) - Brian Donovan <brian@donovans.cc>
@@ -372,17 +507,18 @@ The following packages are licensed under the MIT license:
   - lodash (4.17.21) - John-David Dalton <john.david.dalton@gmail.com>
   - lodash-es (4.17.21) - John-David Dalton <john.david.dalton@gmail.com>
   - lodash.defaults (4.2.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-  - lodash.difference (4.5.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.escaperegexp (4.1.2) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-  - lodash.flatten (4.4.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.isarguments (3.1.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.isequal (4.5.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-  - lodash.isplainobject (4.0.6) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.merge (4.6.2) - John-David Dalton <john.david.dalton@gmail.com>
-  - lodash.union (4.6.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - log-symbols (4.1.0) - Sindre Sorhus
   - longest-streak (3.1.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - loose-envify (1.4.0) - Andres Suarez <zertosh@gmail.com>
+<<<<<<< HEAD
+=======
+  - loupe (3.1.4) - Veselin Todorov <hi@vesln.com>
+  - loupe (3.2.0) - Veselin Todorov <hi@vesln.com>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - lowercase-keys (2.0.0) - Sindre Sorhus
   - luxon (3.7.1) - Isaac Cambron
   - lzma-native (8.0.6) - Anna Henningsen
@@ -450,7 +586,9 @@ The following packages are licensed under the MIT license:
   - mimic-response (3.1.0) - Sindre Sorhus
   - minimist (1.2.8) - James Halliday
   - minipass-fetch (2.1.2) - GitHub Inc.
+  - minipass-fetch (4.0.1) - GitHub Inc.
   - minizlib (2.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - minizlib (3.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - mlly (1.7.4)
   - monaco-editor (0.52.2) - Microsoft Corporation
   - ms (2.1.3)
@@ -463,11 +601,21 @@ The following packages are licensed under the MIT license:
   - negotiator (0.6.4)
   - negotiator (1.0.0)
   - node-abi (3.75.0) - Lukas Geiger
+<<<<<<< HEAD
+=======
+  - node-abi (4.12.0) - Lukas Geiger
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - node-addon-api (1.7.2)
   - node-addon-api (3.2.1)
   - node-addon-api (7.1.1)
   - node-api-version (0.1.4) - Tim Fish <tim@timfish.uk>
   - node-api-version (0.2.1) - Tim Fish <tim@timfish.uk>
+<<<<<<< HEAD
+=======
+  - node-domexception (1.0.0) - Jimmy Wärting
+  - node-fetch (2.7.0) - David Frank
+  - node-gyp (11.2.0) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - node-gyp (9.4.1) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - node-gyp-build (4.8.4) - Mathias Buus (@mafintosh)
   - node-gyp-build-optional-packages (5.2.2) - Mathias Buus (@mafintosh)
@@ -487,6 +635,7 @@ The following packages are licensed under the MIT license:
   - p-limit (3.1.0) - Sindre Sorhus
   - p-locate (5.0.0) - Sindre Sorhus
   - p-map (4.0.0) - Sindre Sorhus
+  - p-map (7.0.3) - Sindre Sorhus
   - package-manager-detector (1.3.0) - Anthony Fu <anthonyfu117@hotmail.com>
   - parent-module (1.0.1) - Sindre Sorhus
   - parse-entities (4.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
@@ -512,6 +661,7 @@ The following packages are licensed under the MIT license:
   - plist (3.1.0) - Nathan Rajlich <nathan@tootallnate.net>
   - points-on-curve (0.2.0) - Preet Shihn
   - points-on-path (0.2.1) - Preet Shihn
+  - postject (1.0.0-alpha.6)
   - prebuild-install (7.1.3) - Mathias Buus (@mafintosh)
   - prelude-ls (1.2.1) - George Zahariev <z@georgezahariev.com>
   - process-nextick-args (2.0.1)
@@ -528,14 +678,27 @@ The following packages are licensed under the MIT license:
   - quick-lru (5.1.1) - Sindre Sorhus
   - range-parser (1.2.1) - TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)
   - raw-body (3.0.0) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
+  - react (18.3.1)
   - react (19.1.0)
+<<<<<<< HEAD
   - react-diff-viewer-continued (3.4.0)
+=======
+  - react-dom (18.3.1)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - react-dom (19.1.0)
   - react-is (16.13.1)
   - react-json-view-lite (1.5.0) - AnyRoad
   - react-refresh (0.17.0)
+<<<<<<< HEAD
   - read-binary-file-arch (1.0.6) - Samuel Maddock
   - read-cache (1.0.0) - Bogdan Chadkin <trysound@yandex.ru>
+=======
+  - react-remove-scroll-bar (2.3.8) - Anton Korzunov <thekashey@gmail.com>
+  - react-style-singleton (2.2.3) - Anton Korzunov (thekashey@gmail.com)
+  - read-binary-file-arch (1.0.6) - Samuel Maddock
+  - read-cache (1.0.0) - Bogdan Chadkin <trysound@yandex.ru>
+  - readable-stream (1.0.34) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - readable-stream (2.3.8)
   - readable-stream (3.6.2)
   - readdirp (3.6.0) - Thorsten Lorenz <thlorenz@gmx.de> (thlorenz.com)
@@ -556,12 +719,14 @@ The following packages are licensed under the MIT license:
   - retry (0.12.0) - Tim Koschützki <tim@debuggable.com> (http://debuggable.com/)
   - reusify (1.1.0) - Matteo Collina <hello@matteocollina.com>
   - rollup (4.45.1) - Rich Harris
+  - rollup (4.46.0) - Rich Harris
   - roughjs (4.6.6) - Preet Shihn <preetshihn@gmail.com>
   - router (2.2.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - run-parallel (1.2.0) - Feross Aboukhadijeh
   - safe-buffer (5.1.2) - Feross Aboukhadijeh
   - safe-buffer (5.2.1) - Feross Aboukhadijeh
   - safer-buffer (2.1.2) - Nikita Skovoroda
+  - scheduler (0.23.2)
   - scheduler (0.26.0)
   - semver-compare (1.0.0) - James Halliday
   - send (1.2.0) - TJ Holowaychuk <tj@vision-media.ca>
@@ -570,6 +735,7 @@ The following packages are licensed under the MIT license:
   - shebang-command (2.0.0) - Kevin Mårtensson
   - shebang-regex (3.0.0) - Sindre Sorhus
   - shell-quote (1.8.3) - James Halliday
+  - shx (0.3.4)
   - side-channel (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - side-channel-list (1.0.0) - Jordan Harband <ljharb@gmail.com>
   - side-channel-map (1.0.1) - Jordan Harband <ljharb@gmail.com>
@@ -581,6 +747,7 @@ The following packages are licensed under the MIT license:
   - smart-buffer (4.2.0) - Josh Glazebrook
   - socks (2.8.6) - Josh Glazebrook
   - socks-proxy-agent (7.0.0) - Nathan Rajlich
+  - socks-proxy-agent (8.0.5) - Nathan Rajlich
   - source-map-support (0.5.21)
   - space-separated-tokens (2.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - standard-as-callback (2.1.0) - luin <i@zihua.li>
@@ -588,6 +755,11 @@ The following packages are licensed under the MIT license:
   - state-local (1.0.7) - Suren Atoyan <contact@surenatoyan.com>
   - statuses (2.0.1)
   - statuses (2.0.2)
+<<<<<<< HEAD
+=======
+  - std-env (3.9.0)
+  - string_decoder (0.10.31)
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - string_decoder (1.1.1)
   - string_decoder (1.3.0)
   - string-width (4.2.3) - Sindre Sorhus
@@ -608,9 +780,12 @@ The following packages are licensed under the MIT license:
   - tailwind-merge (2.6.0) - Dany Castillo
   - tar-fs (2.1.3) - Mathias Buus
   - tar-stream (2.2.0) - Mathias Buus <mathiasbuus@gmail.com>
+  - temp (0.9.4) - Bruce Williams <brwcodes@gmail.com>
   - temp-file (3.4.0) - Vladimir Krivosheev
   - thenify (3.3.1) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
   - thenify-all (1.6.0) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
+  - through2 (2.0.5) - Rod Vagg <r@va.gg> (https://github.com/rvagg)
+  - tiny-async-pool (1.3.0) - Rafael Xavier de Souza
   - tiny-typed-emitter (2.1.0) - Zurab Benashvili <zura.benashvili@gmail.com>
   - tinyexec (1.0.1) - James Garbutt (https://github.com/43081j)
   - tinyglobby (0.2.14) - Superchupu
@@ -618,6 +793,7 @@ The following packages are licensed under the MIT license:
   - tmp-promise (3.0.3) - Benjamin Gruenbaum and Collaborators.
   - to-regex-range (5.0.1) - Jon Schlinkert (https://github.com/jonschlinkert)
   - toidentifier (1.0.1) - Douglas Christopher Wilson <doug@somethingdoug.com>
+  - tr46 (0.0.3) - Sebastian Mayr <npm@smayr.name>
   - tree-kill (1.2.2) - Peteris Krumins
   - trim-lines (3.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - trough (2.2.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
@@ -627,7 +803,9 @@ The following packages are licensed under the MIT license:
   - type-is (2.0.1)
   - ufo (1.6.1)
   - uint8array-extras (1.4.0) - Sindre Sorhus
+  - undici-types (5.26.5)
   - undici-types (6.21.0)
+  - undici-types (7.8.0)
   - unified (11.0.5) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - unist-util-is (6.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - unist-util-position (5.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
@@ -637,6 +815,7 @@ The following packages are licensed under the MIT license:
   - universalify (0.1.2) - Ryan Zimmerman <opensrc@ryanzim.com>
   - universalify (2.0.1) - Ryan Zimmerman <opensrc@ryanzim.com>
   - unpipe (1.0.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
+  - untildify (4.0.0) - Sindre Sorhus
   - update-browserslist-db (1.1.3) - Andrey Sitnik <andrey@sitnik.ru>
   - util-deprecate (1.0.2) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - uuid (11.1.0)
@@ -645,6 +824,7 @@ The following packages are licensed under the MIT license:
   - verror (1.10.1)
   - vfile (6.0.3) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - vfile-message (4.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+  - vfile-message (4.0.3) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - vscode-jsonrpc (8.2.0) - Microsoft Corporation
   - vscode-languageserver (9.0.1) - Microsoft Corporation
   - vscode-languageserver-protocol (3.17.5) - Microsoft Corporation
@@ -652,15 +832,24 @@ The following packages are licensed under the MIT license:
   - vscode-languageserver-types (3.17.5) - Microsoft Corporation
   - vscode-uri (3.0.8) - Microsoft
   - wcwidth (1.0.1) - Tim Oxley
+<<<<<<< HEAD
+=======
+  - web-streams-polyfill (3.3.3) - Mattias Buelens <mattias@buelens.com>
+  - web-streams-polyfill (4.0.0-beta.3) - Mattias Buelens <mattias@buelens.com>
+  - web-streams-polyfill (4.1.0) - Mattias Buelens <mattias@buelens.com>
+  - whatwg-url (5.0.0) - Sebastian Mayr <github@smayr.name>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - when-exit (2.1.4)
   - word-wrap (1.2.5) - Jon Schlinkert (https://github.com/jonschlinkert)
   - wrap-ansi (7.0.0) - Sindre Sorhus
   - wrap-ansi (8.1.0) - Sindre Sorhus
   - xmlbuilder (15.1.1) - Ozgur Ozcitak <oozcitak@gmail.com>
+  - xtend (4.0.2) - Raynos <raynos2@gmail.com>
+  - xterm (5.3.0)
+  - yargs (16.2.0)
   - yargs (17.7.2)
   - yauzl (2.10.0) - Josh Wolfe <thejoshwolfe@gmail.com>
   - yocto-queue (0.1.0) - Sindre Sorhus
-  - zip-stream (4.1.1) - Chris Talkington
   - zod (3.25.76) - Colin McDonnell <zod@colinhacks.com>
   - zwitch (2.0.4) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
@@ -681,16 +870,27 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 The following packages are licensed under the ISC license:
 
   - @isaacs/cliui (8.0.2) - Ben Coe <ben@npmjs.com>
+  - @isaacs/fs-minipass (4.0.1) - Isaac Z. Schlueter
+  - @npmcli/agent (3.0.0) - GitHub Inc.
   - @npmcli/fs (2.1.2) - GitHub Inc.
+  - @npmcli/fs (4.0.0) - GitHub Inc.
   - @ungap/structured-clone (1.3.0) - Andrea Giammarchi
   - abbrev (1.1.1) - Isaac Z. Schlueter <i@izs.me>
+  - abbrev (3.0.1) - GitHub Inc.
   - anymatch (3.1.3) - Elan Shanker
   - aproba (2.1.0) - Rebecca Turner <me@re-becca.org>
   - are-we-there-yet (3.0.1) - GitHub Inc.
   - at-least-node (1.0.0) - Ryan Zimmerman <opensrc@ryanzim.com>
   - cacache (16.1.3) - GitHub Inc.
+<<<<<<< HEAD
   - chownr (1.1.4) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - chownr (2.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+=======
+  - cacache (19.0.1) - GitHub Inc.
+  - chownr (1.1.4) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - chownr (2.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - cliui (7.0.4) - Ben Coe <ben@npmjs.com>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - cliui (8.0.1) - Ben Coe <ben@npmjs.com>
   - color-support (1.1.3) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - console-control-strings (1.1.0) - Rebecca Turner <me@re-becca.org> (http://re-becca.org/)
@@ -726,10 +926,12 @@ The following packages are licensed under the ISC license:
   - d3-zoom (3.0.0) - Mike Bostock
   - delaunator (5.0.1) - Vladimir Agafonkin
   - electron-to-chromium (1.5.187) - Kilian Valkhof
+  - electron-to-chromium (1.5.191) - Kilian Valkhof
   - fastq (1.19.1) - Matteo Collina <hello@matteocollina.com>
   - flatted (3.3.3) - Andrea Giammarchi
   - foreground-child (3.3.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - fs-minipass (2.1.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - fs-minipass (3.0.3) - GitHub Inc.
   - fs.realpath (1.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - gauge (4.0.4) - GitHub Inc.
   - get-caller-file (2.0.5) - Stefan Penner
@@ -749,6 +951,7 @@ The following packages are licensed under the ISC license:
   - internmap (1.0.1) - Mike Bostock
   - internmap (2.0.3) - Mike Bostock
   - isexe (2.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - isexe (3.1.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - json-stringify-safe (5.0.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - lru-cache (10.4.3) - Isaac Z. Schlueter <i@izs.me>
   - lru-cache (11.1.0) - Isaac Z. Schlueter <i@izs.me>
@@ -757,6 +960,7 @@ The following packages are licensed under the ISC license:
   - lru-cache (7.18.3) - Isaac Z. Schlueter <i@izs.me>
   - lucide-react (0.468.0) - Eric Fennis
   - make-fetch-happen (10.2.1) - GitHub Inc.
+  - make-fetch-happen (14.0.3) - GitHub Inc.
   - minimatch (10.0.3) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - minimatch (3.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - minimatch (5.1.6) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
@@ -765,26 +969,49 @@ The following packages are licensed under the ISC license:
   - minipass (5.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - minipass (7.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - minipass-collect (1.0.2) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
+  - minipass-collect (2.0.1) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-flush (1.0.5) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-pipeline (1.2.4) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-sized (1.0.3) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
+  - noms (0.0.0) - Calvin Metcalf
   - nopt (6.0.0) - GitHub Inc.
+  - nopt (8.1.0) - GitHub Inc.
   - npmlog (6.0.2) - GitHub Inc.
   - once (1.4.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - picocolors (1.1.1) - Alexey Raspopov
+  - proc-log (2.0.1) - GitHub Inc.
+  - proc-log (5.0.0) - GitHub Inc.
   - promise-inflight (1.0.1) - Rebecca Turner <me@re-becca.org> (http://re-becca.org/)
   - sax (1.4.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+<<<<<<< HEAD
+=======
+  - semver (5.7.2) - GitHub Inc.
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - semver (6.3.1) - GitHub Inc.
   - semver (7.7.2) - GitHub Inc.
   - set-blocking (2.0.0) - Ben Coe <ben@npmjs.com>
   - setprototypeof (1.2.0) - Wes Todd
+<<<<<<< HEAD
   - signal-exit (3.0.7) - Ben Coe <ben@npmjs.com>
   - signal-exit (4.1.0) - Ben Coe <ben@npmjs.com>
   - ssri (9.0.1) - GitHub Inc.
   - tar (6.2.1) - GitHub Inc.
+=======
+  - siginfo (2.0.0) - Emil Bay <github@tixz.dk>
+  - signal-exit (3.0.7) - Ben Coe <ben@npmjs.com>
+  - signal-exit (4.1.0) - Ben Coe <ben@npmjs.com>
+  - ssri (12.0.0) - GitHub Inc.
+  - ssri (9.0.1) - GitHub Inc.
+  - tar (6.2.1) - GitHub Inc.
+  - tar (7.4.3) - Isaac Z. Schlueter
+  - test-exclude (7.0.1) - Ben Coe <ben@npmjs.com>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - unique-filename (2.0.1) - GitHub Inc.
+  - unique-filename (4.0.0) - GitHub Inc.
   - unique-slug (3.0.0) - GitHub Inc.
+  - unique-slug (5.0.0) - GitHub Inc.
   - which (2.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
+  - which (5.0.0) - GitHub Inc.
   - wide-align (1.1.5) - Rebecca Turner <me@re-becca.org> (http://re-becca.org/)
   - wrappy (1.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - y18n (5.0.8) - Ben Coe <bencoe@gmail.com>
@@ -792,6 +1019,7 @@ The following packages are licensed under the ISC license:
   - yallist (4.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - yaml (1.10.2) - Eemeli Aro <eemeli@gmail.com>
   - yaml (2.8.0) - Eemeli Aro <eemeli@gmail.com>
+  - yargs-parser (20.2.9) - Ben Coe <ben@npmjs.com>
   - yargs-parser (21.1.1) - Ben Coe <ben@npmjs.com>
   - zod-to-json-schema (3.24.6) - Stefan Terdell
 
@@ -828,11 +1056,17 @@ The following packages are licensed under the Apache-2.0 license:
   - @humanwhocodes/retry (0.3.1) - Nicholas C. Zaks
   - @humanwhocodes/retry (0.4.3) - Nicholas C. Zaks
   - @img/sharp-darwin-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+<<<<<<< HEAD
+=======
+  - @img/sharp-darwin-x64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-arm (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-x64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
   - @malept/cross-spawn-promise (2.0.0) - Mark Lee
   - chevrotain (11.0.3) - Shahar Soel
   - class-variance-authority (0.7.1) - Joe Bell (https://joebell.co.uk)
   - cluster-key-slot (1.1.2) - Mike Diarmid
-  - crc-32 (1.2.2) - sheetjs
   - denque (2.1.0) - Invertase
   - detect-libc (2.0.4) - Lovell Fuller <npm@lovell.info>
   - didyoumean (1.2.2) - Dave Porter
@@ -841,7 +1075,7 @@ The following packages are licensed under the Apache-2.0 license:
   - filelist (1.0.4) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
   - jake (10.9.2) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
   - openai (5.10.1) - OpenAI <support@openai.com>
-  - readdir-glob (1.1.3) - Yann Armelin
+  - openai (5.10.2) - OpenAI <support@openai.com>
   - rxjs (7.8.2) - Ben Lesh <ben@benlesh.com>
   - sumchecker (3.0.1) - Mark Lee
   - ts-interface-checker (0.1.13) - Dmitry S, Grist Labs
@@ -1591,6 +1825,39 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
+Package: shelljs
+Version: 0.8.5
+Homepage: http://github.com/shelljs/shelljs
+
+Copyright (c) 2012, Artur Adib <arturadib@gmail.com>
+All rights reserved.
+
+You may use this project under the terms of the New BSD license as follows:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Artur Adib nor the
+      names of the contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL ARTUR ADIB BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
 Package: source-map
 Version: 0.5.7
 Author: Nick Fitzgerald <nfitzgerald@mozilla.com>
@@ -1735,7 +2002,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following packages are licensed under the BSD-2-Clause license:
 
   - @electron/osx-sign (1.3.1) - electron
+  - @electron/windows-sign (1.2.2) - Felix Rieseberg
   - dotenv (16.6.1)
+  - dotenv (17.2.1)
   - dotenv-expand (11.0.7) - motdotla
   - espree (10.4.0) - Nicholas C. Zakas <nicholas+npm@nczconsulting.com>
   - esrecurse (4.3.0)
@@ -1745,6 +2014,7 @@ The following packages are licensed under the BSD-2-Clause license:
   - http-cache-semantics (4.2.0) - Kornel Lesiński <npms2@geekhood.net> (https://kornel.ski/)
   - json-schema-typed (8.0.1) - Jeremy Rylan
   - uri-js (4.4.1) - Gary Court <gary.court@gmail.com>
+  - webidl-conversions (3.0.1) - Domenic Denicola <d@domenic.me> (https://domenic.me/)
 
 Copyright (c) Electron contributors
 Copyright (c) 2015-2016 Zhuo Lu, Jason Hinkle, et al.
@@ -1774,6 +2044,77 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 ## BlueOak-1.0.0 LICENSE
 ================================================================================
+
+Package: chownr
+Version: 3.0.0
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+Repository: git://github.com/isaacs/chownr.git
+
+All packages under `src/` are licensed according to the terms in
+their respective `LICENSE` or `LICENSE.md` files.
+
+The remainder of this project is licensed under the Blue Oak
+Model License, as follows:
+
+-----
+
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***
+
+--------------------------------------------------------------------------------
 
 Package: jackspeak
 Version: 3.4.3
@@ -2098,6 +2439,126 @@ software or this license, under any kind of legal claim.***
 
 --------------------------------------------------------------------------------
 
+Package: yallist
+Version: 5.0.0
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+Repository: git+https://github.com/isaacs/yallist.git
+
+All packages under `src/` are licensed according to the terms in
+their respective `LICENSE` or `LICENSE.md` files.
+
+The remainder of this project is licensed under the Blue Oak
+Model License, as follows:
+
+-----
+
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***
+
+--------------------------------------------------------------------------------
+
+================================================================================
+## LGPL-3.0-or-later LICENSE
+================================================================================
+
+Package: @img/sharp-libvips-darwin-arm64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-darwin-x64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-arm
+Version: 1.0.5
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-arm64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-x64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
 ================================================================================
 ## Unknown LICENSE
 ================================================================================
@@ -2158,6 +2619,36 @@ DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
+Package: rechoir
+Version: 0.6.2
+Author: Tyler Kellen
+Homepage: https://github.com/tkellen/node-rechoir
+
+Copyright (c) 2015 Tyler Kellen
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
 Package: stubborn-fs
 Version: 1.2.5
 Repository: github:fabiospampinato/stubborn-fs
@@ -2187,6 +2678,31 @@ DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------
 
 ================================================================================
+<<<<<<< HEAD
+=======
+## SEE LICENSE IN README.md LICENSE
+================================================================================
+
+Package: @anthropic-ai/claude-code
+Version: 1.0.56
+Author: Anthropic <support@anthropic.com>
+Homepage: https://github.com/anthropics/claude-code
+
+© Anthropic PBC. All rights reserved. Use is subject to Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
+
+--------------------------------------------------------------------------------
+
+Package: @anthropic-ai/claude-code
+Version: 1.0.61
+Author: Anthropic <support@anthropic.com>
+Homepage: https://github.com/anthropics/claude-code
+
+© Anthropic PBC. All rights reserved. Use is subject to Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
+
+--------------------------------------------------------------------------------
+
+================================================================================
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
 ## (BSD-2-Clause OR MIT OR Apache-2.0) LICENSE
 ================================================================================
 
@@ -3540,7 +4056,11 @@ For more information, please refer to <http://unlicense.org>
 ================================================================================
 
 Package: Crystal
+<<<<<<< HEAD
 Version: 0.1.16
+=======
+Version: 0.1.17
+>>>>>>> 7a905d2 (Add Windows compatibility and fix notification settings synchronization)
 Author: [object Object]
 License: MIT
 

--- a/frontend/src/components/AboutDialog.tsx
+++ b/frontend/src/components/AboutDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { X, ExternalLink, Download, Check, AlertCircle, Loader2 } from 'lucide-react';
 import { UpdateDialog } from './UpdateDialog';
+import { getBasename } from '../utils/pathUtils';
 
 interface VersionInfo {
   current: string;
@@ -174,7 +175,7 @@ export function AboutDialog({ isOpen, onClose }: AboutDialogProps) {
                   Working Directory
                 </span>
                 <span className="text-sm text-text-primary font-mono truncate max-w-[200px]" title={versionInfo.workingDirectory}>
-                  {versionInfo.workingDirectory.split('/').pop() || versionInfo.workingDirectory}
+                  {getBasename(versionInfo.workingDirectory) || versionInfo.workingDirectory}
                 </span>
               </div>
             )}

--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '../contexts/ThemeContext';
 import { debounce } from '../utils/debounce';
 import { MarkdownPreview } from './MarkdownPreview';
 import { useResizablePanel } from '../hooks/useResizablePanel';
+import { getParentPath } from '../utils/pathUtils';
 
 interface FileItem {
   name: string;
@@ -218,7 +219,7 @@ function FileTree({ sessionId, onFileSelect, selectedPath }: FileTreeProps) {
       
       if (result.success) {
         // Refresh the parent directory
-        const parentPath = file.path.split('/').slice(0, -1).join('/') || '';
+        const parentPath = getParentPath(file.path);
         loadFiles(parentPath);
         
         // If the deleted file was selected, clear the selection

--- a/frontend/src/components/FilePathAutocomplete.tsx
+++ b/frontend/src/components/FilePathAutocomplete.tsx
@@ -15,7 +15,7 @@ interface FilePathAutocompleteProps {
   projectId?: string;
   placeholder?: string;
   className?: string;
-  textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
+  textareaRef?: React.RefObject<HTMLTextAreaElement>;
   isTextarea?: boolean;
   rows?: number;
   disabled?: boolean;

--- a/frontend/src/components/SessionListItem.tsx
+++ b/frontend/src/components/SessionListItem.tsx
@@ -8,6 +8,7 @@ import { API } from '../utils/api';
 import { Star, Archive } from 'lucide-react';
 import type { Session, GitStatus } from '../types/session';
 import { useContextMenu } from '../contexts/ContextMenuContext';
+import { getBasename } from '../utils/pathUtils';
 import { IconButton } from './ui/IconButton';
 import { cn } from '../utils/cn';
 
@@ -501,7 +502,7 @@ export const SessionListItem = memo(function SessionListItem({ session, isNested
         onClose={() => setShowArchiveConfirm(false)}
         onConfirm={handleConfirmArchive}
         title={`Archive Session`}
-        message={`Archive session "${session.name}"? This will:\n\n• Move the session to the archived sessions list\n• Preserve all session history and outputs\n${session.isMainRepo ? '• Close the active Claude Code connection' : `• Remove the git worktree locally (${session.worktreePath?.split('/').pop() || 'worktree'})`}`}
+        message={`Archive session "${session.name}"? This will:\n\n• Move the session to the archived sessions list\n• Preserve all session history and outputs\n${session.isMainRepo ? '• Close the active Claude Code connection' : `• Remove the git worktree locally (${session.worktreePath ? getBasename(session.worktreePath) : 'worktree'})`}`}
         confirmText="Archive"
         confirmButtonClass="bg-amber-600 hover:bg-amber-700 text-white"
         icon={<Archive className="w-6 h-6 text-amber-500 flex-shrink-0" />}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -46,7 +46,7 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'general' | 'notifications' | 'stravu'>('general');
-  const { updateSettings } = useNotifications();
+  const { updateSettings, reloadSettings } = useNotifications();
   const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
@@ -101,6 +101,12 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
 
       // Update the useNotifications hook with new settings
       updateSettings(notificationSettings);
+      
+      // Reload settings from backend to ensure all instances are synced
+      await reloadSettings();
+      
+      // Dispatch event to notify all instances to reload settings
+      window.dispatchEvent(new Event('notification-settings-updated'));
 
       // Refresh config from server
       await fetchConfig();

--- a/frontend/src/components/session/SessionInput.tsx
+++ b/frontend/src/components/session/SessionInput.tsx
@@ -3,13 +3,14 @@ import { Session } from '../../types/session';
 import { ViewMode } from '../../hooks/useSessionView';
 import { Cpu } from 'lucide-react';
 import { API } from '../../utils/api';
+import { getModifierKeyWithEnter } from '../../utils/platform';
 
 interface SessionInputProps {
   activeSession: Session;
   viewMode: ViewMode;
   input: string;
   setInput: (input: string) => void;
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
   handleTerminalCommand: () => void;
   handleSendInput: () => void;
   handleContinueConversation: (model?: string) => void;
@@ -71,9 +72,10 @@ export const SessionInput: React.FC<SessionInputProps> = ({
     }
   };
 
+  const modifierKey = getModifierKeyWithEnter();
   const placeholder = viewMode === 'terminal'
-    ? (activeSession.isRunning ? "Script is running..." : (activeSession.status === 'waiting' ? "Enter your response... (⌘↵ to send)" : "Enter terminal command... (⌘↵ to send)"))
-    : (activeSession.status === 'waiting' ? "Enter your response... (⌘↵ to send)" : "Continue conversation... (⌘↵ to send)");
+    ? (activeSession.isRunning ? "Script is running..." : (activeSession.status === 'waiting' ? `Enter your response... (${modifierKey} to send)` : `Enter terminal command... (${modifierKey} to send)`))
+    : (activeSession.status === 'waiting' ? `Enter your response... (${modifierKey} to send)` : `Continue conversation... (${modifierKey} to send)`);
 
   return (
     <div className="border-t border-border-primary p-4 bg-surface-primary flex-shrink-0">

--- a/frontend/src/components/session/SessionInputWithImages.tsx
+++ b/frontend/src/components/session/SessionInputWithImages.tsx
@@ -8,6 +8,8 @@ import { CommitModePill, AutoCommitSwitch } from '../CommitModeToggle';
 import { Dropdown, type DropdownItem } from '../ui/Dropdown';
 import { Pill } from '../ui/Pill';
 import { SwitchSimple as Switch } from '../ui/SwitchSimple';
+import { getPathTail } from '../../utils/pathUtils';
+import { getModifierKeyWithEnter } from '../../utils/platform';
 
 interface AttachedImage {
   id: string;
@@ -22,7 +24,7 @@ interface SessionInputWithImagesProps {
   viewMode: ViewMode;
   input: string;
   setInput: (input: string) => void;
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
   handleTerminalCommand: () => void;
   handleSendInput: (attachedImages?: AttachedImage[]) => void;
   handleContinueConversation: (attachedImages?: AttachedImage[], model?: string) => void;
@@ -295,7 +297,7 @@ export const SessionInputWithImages: React.FC<SessionInputWithImagesProps> = mem
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
                 </svg>
                 <span className="leading-none">
-                  {activeSession.worktreePath.split('/').slice(-3, -2)[0] || 'Project'}
+                  {getPathTail(activeSession.worktreePath, 3).split(/[/\\]/)[0] || 'Project'}
                 </span>
               </div>
               
@@ -593,6 +595,7 @@ export const SessionInputWithImages: React.FC<SessionInputWithImagesProps> = mem
                         : 'bg-surface-secondary hover:bg-surface-hover text-interactive hover:text-interactive-hover border-border-primary focus:ring-interactive'
                     }
                   `}
+                  title={`${buttonConfig.text} (${getModifierKeyWithEnter()})`}
                 >
                   <ButtonIcon className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5" />
                   <span className="font-semibold">{buttonConfig.text}</span>
@@ -600,9 +603,8 @@ export const SessionInputWithImages: React.FC<SessionInputWithImagesProps> = mem
                   {/* Inline keyboard shortcut */}
                   <span 
                     className="ml-2 text-xs font-mono bg-white/10 px-1.5 py-0.5 rounded opacity-80 group-hover:opacity-100 transition-opacity"
-                    title="Keyboard Shortcut: ⌘ + Enter"
                   >
-                    ⌘⏎
+                    {getModifierKeyWithEnter()}
                   </span>
                 </button>
               )}

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -1626,7 +1626,7 @@ export const useSessionView = (
     setShouldSquash,
     isWaitingForFirstOutput,
     elapsedTime,
-    textareaRef,
+    textareaRef: textareaRef as React.RefObject<HTMLTextAreaElement>,
     handleSendInput,
     handleContinueConversation,
     handleTerminalCommand,

--- a/frontend/src/utils/pathUtils.ts
+++ b/frontend/src/utils/pathUtils.ts
@@ -1,0 +1,88 @@
+/**
+ * Path utilities for the frontend
+ * These functions handle cross-platform path operations in the browser
+ */
+
+/**
+ * Get the path separator for the current platform
+ * This is determined from paths received from the backend
+ */
+export function getPathSeparator(samplePath?: string): string {
+  // If we have a sample path, detect the separator
+  if (samplePath) {
+    if (samplePath.includes('\\') && !samplePath.includes('/')) {
+      return '\\';
+    }
+  }
+  
+  // Default to forward slash (works for Unix and URLs)
+  return '/';
+}
+
+/**
+ * Get the parent directory of a path
+ * Works with both Windows and Unix paths
+ */
+export function getParentPath(filePath: string): string {
+  const separator = getPathSeparator(filePath);
+  const parts = filePath.split(separator);
+  
+  // Remove the last part (filename or directory)
+  parts.pop();
+  
+  // Join back together
+  return parts.join(separator) || '';
+}
+
+/**
+ * Get the basename (filename) from a path
+ * Works with both Windows and Unix paths
+ */
+export function getBasename(filePath: string): string {
+  const separator = getPathSeparator(filePath);
+  const parts = filePath.split(separator);
+  return parts[parts.length - 1] || '';
+}
+
+/**
+ * Join path segments
+ * Automatically detects the separator to use
+ */
+export function joinPath(...segments: string[]): string {
+  if (segments.length === 0) return '';
+  
+  // Detect separator from the first segment that contains one
+  let separator = '/';
+  for (const segment of segments) {
+    if (segment.includes('\\') && !segment.includes('/')) {
+      separator = '\\';
+      break;
+    }
+  }
+  
+  // Filter out empty segments and join
+  return segments.filter(s => s).join(separator);
+}
+
+/**
+ * Normalize a path (remove redundant separators, etc.)
+ */
+export function normalizePath(filePath: string): string {
+  const separator = getPathSeparator(filePath);
+  
+  // Split by separator and filter out empty parts
+  const parts = filePath.split(separator).filter(part => part);
+  
+  // Rejoin with consistent separator
+  return parts.join(separator);
+}
+
+/**
+ * Get the last N parts of a path
+ * Useful for displaying shortened paths
+ */
+export function getPathTail(filePath: string, n: number = 1): string {
+  const separator = getPathSeparator(filePath);
+  const parts = filePath.split(separator);
+  return parts.slice(-n).join(separator);
+}

--- a/frontend/src/utils/platform.ts
+++ b/frontend/src/utils/platform.ts
@@ -1,0 +1,33 @@
+/**
+ * Platform detection utilities for the frontend
+ */
+
+/**
+ * Detect if the current platform is macOS
+ */
+export function isMac(): boolean {
+  // Check for Mac using navigator.platform or navigator.userAgent
+  return /Mac|iPhone|iPod|iPad/i.test(navigator.platform) || 
+         /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent);
+}
+
+/**
+ * Get the modifier key name for keyboard shortcuts
+ */
+export function getModifierKey(): string {
+  return isMac() ? '⌘' : 'Ctrl';
+}
+
+/**
+ * Get the modifier key with Enter for keyboard shortcuts
+ */
+export function getModifierKeyWithEnter(): string {
+  return isMac() ? '⌘↵' : 'Ctrl+Enter';
+}
+
+/**
+ * Get the full modifier key name for display
+ */
+export function getModifierKeyName(): string {
+  return isMac() ? 'Command' : 'Ctrl';
+}

--- a/main/package.json
+++ b/main/package.json
@@ -8,7 +8,7 @@
     "dev": "tsc -w",
     "build": "rimraf dist && tsc && npm run copy:assets && npm run bundle:mcp",
     "bundle:mcp": "node build-mcp-bridge.js",
-    "copy:assets": "mkdirp dist/main/src/database/migrations && cp src/database/*.sql dist/main/src/database/ && cp src/database/migrations/*.sql dist/main/src/database/migrations/",
+    "copy:assets": "shx mkdir -p dist/main/src/database/migrations && shx cp src/database/*.sql dist/main/src/database/ && shx cp src/database/migrations/*.sql dist/main/src/database/migrations/",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
@@ -41,6 +41,7 @@
     "eslint": "^9.17.0",
     "mkdirp": "^3.0.1",
     "rimraf": "^6.0.1",
+    "shx": "^0.3.4",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { readFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import type { Project, ProjectRunCommand, Folder, Session, SessionOutput, CreateSessionData, UpdateSessionData, ConversationMessage, PromptMarker, ExecutionDiff, CreateExecutionDiffData } from './models';
 
 export class DatabaseService {
@@ -181,7 +181,7 @@ export class DatabaseService {
         const gitRepoPath = configManager.getGitRepoPath();
         
         if (gitRepoPath) {
-          const projectName = gitRepoPath.split('/').pop() || 'Default Project';
+          const projectName = basename(gitRepoPath) || 'Default Project';
           const result = this.db.prepare(`
             INSERT INTO projects (name, path, active)
             VALUES (?, ?, 1)

--- a/package.json
+++ b/package.json
@@ -33,10 +33,13 @@
     "build:linux": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --linux --publish never",
     "build:linux:ci": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --linux --publish never",
     "build:mac:ci": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && node scripts/configure-build.js && electron-builder --mac --publish never",
+    "build:win": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --win --publish never",
+    "build:win:ci": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --win --publish never",
     "inject-build-info": "node scripts/inject-build-info.js",
     "release:mac": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && node scripts/configure-build.js && electron-builder --mac --publish always",
     "release:mac:universal": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && node scripts/configure-build.js && electron-builder --mac --universal --publish always",
     "release:linux": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --linux --publish always",
+    "release:win": "pnpm run build:frontend && pnpm run build:main && pnpm run inject-build-info && pnpm run generate-notices && electron-builder --win --publish always",
     "preview": "pnpm run --filter frontend preview",
     "lint": "pnpm run -r lint",
     "typecheck": "pnpm run -r typecheck",
@@ -157,6 +160,33 @@
     },
     "appImage": {
       "artifactName": "${productName}-${version}-linux-${arch}.${ext}"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "main/assets/icon.ico",
+      "publisherName": "Crystal Team",
+      "artifactName": "${productName}-${version}-Windows-${arch}.${ext}"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "${productName}-${version}-Windows-Setup.${ext}"
+    },
+    "portable": {
+      "artifactName": "${productName}-${version}-Windows-Portable.${ext}"
     },
     "publish": {
       "provider": "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
       typescript:
         specifier: ^5.7.2
         version: 5.8.3
@@ -3179,6 +3182,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
+
   ioredis@5.6.1:
     resolution: {integrity: sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==}
     engines: {node: '>=12.22.0'}
@@ -4218,6 +4225,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -4371,6 +4382,16 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shelljs@0.8.5:
+    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  shx@0.3.4:
+    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -8182,6 +8203,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  interpret@1.4.0: {}
+
   ioredis@5.6.1:
     dependencies:
       '@ioredis/commands': 1.2.0
@@ -9425,6 +9448,10 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  rechoir@0.6.2:
+    dependencies:
+      resolve: 1.22.10
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
@@ -9630,6 +9657,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shelljs@0.8.5:
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+
+  shx@0.3.4:
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.8.5
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## Description
This PR adds full Windows compatibility to Crystal while fixing an existing issue where the notification toggle doesn't properly disable notifications. The changes ensure Crystal works on Windows without breaking macOS/Linux compatibility.

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist
<!-- Please check all that apply -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
<!-- Check if you modified any of these critical areas -->
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [x] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
- Adds a platform aware Continue Button on the output screen:
<img width="234" height="66" alt="0JVDihw - Imgur" src="https://github.com/user-attachments/assets/f6941d56-c908-4bda-8e2e-21e8302e33c0" />

## Additional Notes
- **Windows Path Handling**: Adds cross-platform path utilities to handle Windows backslashes vs Unix forward slashes
- **Worktree Deletion Fix**: Resolves issue where terminal sessions hold file locks on Windows, preventing worktree deletion
- **Notification Settings Fix**: Fixes synchronization issue where notification toggle wasn't properly disabling notifications across all hook instances
- **Build Scripts**: Updates build scripts to use cross-platform commands with `shx`
- **TypeScript Fixes**: Resolves ref type issues that prevent compilation on Windows
- **Testing Note**: The test suite itself needs Windows compatibility updates (uses Unix commands like `touch`). This will be addressed in a follow-up PR as discussed.

All changes maintain backward compatibility with macOS and Linux.