### PR TITLE
Move add folder from a menu item to a button on the project

### DIFF
--- a/frontend/src/components/DraggableProjectTreeView.tsx
+++ b/frontend/src/components/DraggableProjectTreeView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { ChevronRight, ChevronDown, Folder as FolderIcon, FolderOpen, Plus, Settings, GripVertical, Archive, GitBranch, RefreshCw, Play } from 'lucide-react';
+import { ChevronRight, ChevronDown, Folder as FolderIcon, FolderOpen, Plus, Settings, GripVertical, Archive, GitBranch, RefreshCw, Play, FolderPlus } from 'lucide-react';
 import { useSessionStore } from '../stores/sessionStore';
 import { useErrorStore } from '../stores/errorStore';
 import { useNavigationStore } from '../stores/navigationStore';
@@ -1671,6 +1671,19 @@ export function DraggableProjectTreeView() {
                 </button>
 
                 <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedProjectForFolder(project);
+                    setShowCreateFolderDialog(true);
+                    setNewFolderName('');
+                  }}
+                  className="p-1 hover:bg-surface-hover rounded transition-all opacity-0 group-hover:opacity-100"
+                  title="Add folder"
+                >
+                  <FolderPlus className="w-3 h-3 text-text-tertiary hover:text-text-primary" />
+                </button>
+
+                <button
                   onClick={(e) => handleRefreshProjectGitStatus(project, e)}
                   disabled={refreshingProjects.has(project.id)}
                   className={`p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-all opacity-0 group-hover:opacity-100 ${
@@ -1775,21 +1788,6 @@ export function DraggableProjectTreeView() {
                       })}
                   </div>
                   
-                  {/* Add folder button */}
-                  <div className="ml-6 mt-2 border-t border-border-primary pt-2">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedProjectForFolder(project);
-                        setShowCreateFolderDialog(true);
-                        setNewFolderName('');
-                      }}
-                      className="w-full px-2 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded transition-colors flex items-center space-x-1"
-                    >
-                      <Plus className="w-3 h-3" />
-                      <span>Add Folder</span>
-                    </button>
-                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Description
Simple change to move the "Add Folder" menu item in the project tree view to being an icon button on the project to the right of new session.

Just trying to reduce visual clutter when you have many projects open

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Please check all that apply -->
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
<!-- Check if you modified any of these critical areas -->
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
<img width="475" height="100" alt="image" src="https://github.com/user-attachments/assets/d764d074-ac1b-46a4-ace4-bae4418aa79d" />

## Additional Notes
<!-- Add any additional notes or context about the PR here -->