### PR TITLE
fix: update backend to allow revert button to show correctly

### DIFF
--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -57,7 +57,7 @@ export function registerGitHandlers(ipcMain: IpcMain, services: AppServices): vo
         id: index + 1, // 1-based index for commits
         session_id: sessionId,
         execution_sequence: index + 1,
-        commit_hash: commit.hash,
+        after_commit_hash: commit.hash,
         commit_message: commit.message,
         timestamp: commit.date.toISOString(),
         stats_additions: commit.stats.additions,
@@ -77,7 +77,7 @@ export function registerGitHandlers(ipcMain: IpcMain, services: AppServices): vo
           id: 0,
           session_id: sessionId,
           execution_sequence: 0,
-          commit_hash: 'UNCOMMITTED',
+          after_commit_hash: 'UNCOMMITTED',
           commit_message: 'Uncommitted changes',
           timestamp: new Date().toISOString(),
           stats_additions: uncommittedDiff.stats.additions,


### PR DESCRIPTION
## Description
The backend was using  instead of  that the frontend expects for the commit revert button. This has been updated in the git IPC handler (main/src/ipc/git.ts:60 and main/src/ipc/git.ts:80) to use  instead, which should make the revert button appear properly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
<img width="337" height="164" alt="Screenshot 2025-08-09 at 12 38 26 pm" src="https://github.com/user-attachments/assets/622892aa-ed82-42a7-85a4-82a3c62b5c84" />

## Additional Notes
<!-- Add any additional notes or context about the PR here -->